### PR TITLE
Nokogiri version

### DIFF
--- a/dor-services.gemspec
+++ b/dor-services.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'json', '~> 1.8.1'
   s.add_dependency 'net-sftp', '~> 2.1.2'
   s.add_dependency 'net-ssh', '~> 2.7.0'
-  s.add_dependency 'nokogiri', '1.6.0'
+  s.add_dependency 'nokogiri', '~> 1.6.0'
   s.add_dependency 'om', '~> 1.8.0'
   s.add_dependency 'progressbar', '~> 0.21.0'
   s.add_dependency 'rdf', '~> 1.0.9.0' # 1.0.10 breaks


### PR DESCRIPTION
Nokogiri 1.6.0 has an active security alert when run under JRuby.
