### PR TITLE
ARGO-309:  fix administrativeMetadata handling in default_workflow= 

### DIFF
--- a/lib/dor/models/editable.rb
+++ b/lib/dor/models/editable.rb
@@ -244,7 +244,8 @@ module Dor
       else
         nodes=xml.search('//registration')
         if not nodes.first
-          self.administrativeMetadata.add_child_node(self.administrativeMetadata.ng_xml.root, :registration)
+          reg_node=Nokogiri::XML::Node.new('registration',xml)
+          xml.root.add_child(reg_node)
         end
         nodes=xml.search('//registration')
         wf_node=Nokogiri::XML::Node.new('workflow',xml)

--- a/spec/dor/editable_spec.rb
+++ b/spec/dor/editable_spec.rb
@@ -268,6 +268,15 @@ describe Dor::Editable do
     it 'should work on an empty ds' do
       @empty_item.default_workflow = 'thisWF'
       @empty_item.default_workflows.include?('thisWF').should == true
+      adm_md_ds = @empty_item.datastreams['administrativeMetadata']
+      xml = Nokogiri::XML(adm_md_ds.to_xml)
+      xml.should be_equivalent_to <<-XML
+        <administrativeMetadata>
+          <registration>
+            <workflow id="thisWF"/>
+          </registration>
+        </administrativeMetadata>
+      XML
     end
   end
   describe 'to_solr' do


### PR DESCRIPTION
don't add child administrativeMetadata node to the parent administrativeMetadata node.  corresponding unit test coverage. (fix actually courtesy of willy, i'm just checking it in)
