### PR TITLE
ARGO-302: add support for renamed DOR-wide roles: dlss:dor-admin -> sdr:...

### DIFF
--- a/lib/dor/models/governable.rb
+++ b/lib/dor/models/governable.rb
@@ -120,28 +120,28 @@ module Dor
       end
     end
     def groups_which_manage_item
-      ['dor-administrator','dor-apo-manager', 'dor-apo-depositor']
+      ['dor-administrator', 'sdr-administrator', 'dor-apo-manager', 'dor-apo-depositor']
     end
     def groups_which_manage_desc_metadata
-      ['dor-administrator','dor-apo-manager', 'dor-apo-depositor', 'dor-apo-metadata']
+      ['dor-administrator', 'sdr-administrator', 'dor-apo-manager', 'dor-apo-depositor', 'dor-apo-metadata']
     end
     def groups_which_manage_system_metadata
-      ['dor-administrator','dor-apo-manager', 'dor-apo-depositor']
+      ['dor-administrator', 'sdr-administrator', 'dor-apo-manager', 'dor-apo-depositor']
     end
     def groups_which_manage_content
-      ['dor-administrator','dor-apo-manager', 'dor-apo-depositor']
+      ['dor-administrator', 'sdr-administrator', 'dor-apo-manager', 'dor-apo-depositor']
     end
     def groups_which_manage_rights
-      ['dor-administrator','dor-apo-manager', 'dor-apo-depositor']
+      ['dor-administrator', 'sdr-administrator', 'dor-apo-manager', 'dor-apo-depositor']
     end
     def groups_which_manage_embargo
-      ['dor-administrator','dor-apo-manager', 'dor-apo-depositor']
+      ['dor-administrator', 'sdr-administrator', 'dor-apo-manager', 'dor-apo-depositor']
     end
     def groups_which_view_content
-      ['dor-administrator','dor-apo-manager', 'dor-apo-depositor', 'dor-viewer']
+      ['dor-administrator', 'sdr-administrator', 'dor-apo-manager', 'dor-apo-depositor', 'dor-viewer', 'sdr-viewer']
     end
     def groups_which_view_metadata
-      ['dor-administrator','dor-apo-manager', 'dor-apo-depositor', 'dor-viewer']
+      ['dor-administrator', 'sdr-administrator', 'dor-apo-manager', 'dor-apo-depositor', 'dor-viewer', 'sdr-viewer']
     end
     def intersect arr1, arr2
       return (arr1 & arr2).length > 0

--- a/spec/dor/governable_spec.rb
+++ b/spec/dor/governable_spec.rb
@@ -291,8 +291,11 @@ it 'should add a collection' do
 	  end
 	end
 	describe 'can_manage_item?' do
-	  it 'should match a group that has rights' do
+    it 'should match a group that has rights' do
       @item.can_manage_item?(['dor-administrator']).should == true
+    end
+    it 'should match a group that has rights' do
+      @item.can_manage_item?(['sdr-administrator']).should == true
     end
     it 'shouldnt match a group that doesnt have rights' do
       @item.can_manage_item?(['dor-apo-metadata']).should == false
@@ -303,12 +306,18 @@ it 'should add a collection' do
       @item.can_manage_desc_metadata?(['dor-apo-metadata']).should == true
     end
     it 'shouldnt match a group that doesnt have rights' do
-      @item.can_manage_desc_metadata?(['dor-viewers']).should == false
+      @item.can_manage_desc_metadata?(['dor-viewer']).should == false
+    end
+    it 'shouldnt match a group that doesnt have rights' do
+      @item.can_manage_desc_metadata?(['sdr-viewer']).should == false
     end
   end
   describe 'can_manage_content?' do
     it 'should match a group that has rights' do
       @item.can_manage_content?(['dor-administrator']).should == true
+    end
+    it 'should match a group that has rights' do
+      @item.can_manage_content?(['sdr-administrator']).should == true
     end
     it 'shouldnt match a group that doesnt have rights' do
       @item.can_manage_content?(['dor-apo-metadata']).should == false
@@ -318,6 +327,9 @@ it 'should add a collection' do
     it 'should match a group that has rights' do
       @item.can_manage_rights?(['dor-administrator']).should == true
     end
+    it 'should match a group that has rights' do
+      @item.can_manage_rights?(['sdr-administrator']).should == true
+    end
     it 'shouldnt match a group that doesnt have rights' do
       @item.can_manage_rights?(['dor-apo-metadata']).should == false
     end
@@ -325,6 +337,9 @@ it 'should add a collection' do
   describe 'can_manage_embargo?' do
     it 'should match a group that has rights' do
       @item.can_manage_embargo?(['dor-administrator']).should == true
+    end
+    it 'should match a group that has rights' do
+      @item.can_manage_embargo?(['sdr-administrator']).should == true
     end
     it 'shouldnt match a group that doesnt have rights' do
       @item.can_manage_embargo?(['dor-apo-metadata']).should == false
@@ -334,6 +349,9 @@ it 'should add a collection' do
     it 'should match a group that has rights' do
       @item.can_view_content?(['dor-viewer']).should == true
     end
+    it 'should match a group that has rights' do
+      @item.can_view_content?(['sdr-viewer']).should == true
+    end
     it 'shouldnt match a group that doesnt have rights' do
       @item.can_view_content?(['dor-people']).should == false
     end
@@ -341,6 +359,9 @@ it 'should add a collection' do
   describe 'can_view_metadata?' do
     it 'should match a group that has rights' do
       @item.can_view_metadata?(['dor-viewer']).should == true
+    end
+    it 'should match a group that has rights' do
+      @item.can_view_metadata?(['sdr-viewer']).should == true
     end
     it 'shouldnt match a group that doesnt have rights' do
       @item.can_view_metadata?(['dor-people']).should == false


### PR DESCRIPTION
...administrator-role, dlss:dor-manager -> sdr:manager-role, dlss:dor-viewer -> sdr:viewer-role

sorry, that wasn't the best commit message, in retrospect.  what actually got renamed here are the "dor-administrator" and "dor-viewer" roles that are defined in APOs (and which list workgroups/users), so that the APO role names would better correspond with the new workgroup names.  since both workgroup namings still exist at present (with the dlss:dor- groups as aliases for the new sdr: groups), this code change adds support for the new role/group names while leaving support for the old role/group names in place for now.  when the old group names no longer exist and the old role names have all been switched to the new ones, we can pull support for the old names.
