### PR TITLE
ARGO-346:  include Versionable

### DIFF
--- a/lib/dor/models/set.rb
+++ b/lib/dor/models/set.rb
@@ -5,6 +5,7 @@ module Dor
     include Governable
     include Describable
     include Publishable
+    include Versionable
 
     has_many :members, :property => :is_member_of_collection, :inbound => true, :class_name => "ActiveFedora::Base"
     has_object_type 'set'


### PR DESCRIPTION
so that the versionMetadata datastream has the correct type (Dor::VersionMetadataDS instead of ActiveFedora::Datastream) when an object is created using Dor.load_instance
