### PR TITLE
ARGO-308: adminPolicy field on identity metadata datastream is deprecated

### DIFF
--- a/lib/dor/models/governable.rb
+++ b/lib/dor/models/governable.rb
@@ -28,10 +28,7 @@ module Dor
 
     def reset_to_apo_default()
       rights_metadata_ds = self.rightsMetadata
-      #get the apo for this object
-      apo_druid=obj.identityMetadata.adminPolicy.first
-      apo_obj=Dor::Item.find(apo_druid, :lightweight => true)
-      rights_metadata_ds.content=apo_obj.rightsMetadata.ng_xml
+      rights_metadata_ds.content = admin_policy_object.rightsMetadata.ng_xml
     end
 
     def set_read_rights(rights)

--- a/lib/dor/services/registration_service.rb
+++ b/lib/dor/services/registration_service.rb
@@ -73,7 +73,6 @@ module Dor
         idmd.add_value(:objectCreator, 'DOR')
         idmd.add_value(:objectLabel, label)
         idmd.add_value(:objectType, object_type)
-        idmd.add_value(:adminPolicy, admin_policy)
         other_ids.each_pair { |name,value| idmd.add_otherId("#{name}:#{value}") }
         tags.each { |tag| idmd.add_value(:tag, tag) }
         new_item.admin_policy_object = apo_object


### PR DESCRIPTION
remove the line that sets it, fix the one method that seems to reference that field (reset_to_apo_default)
