### PR TITLE
Update moab-versioning

### DIFF
--- a/dor-services.gemspec
+++ b/dor-services.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'dor-workflow-service', '~> 1.7', '>= 1.7.1'
   s.add_dependency 'druid-tools', '~> 0.3.1'
   s.add_dependency 'lyber-utils', '~> 0.1.2'
-  s.add_dependency 'moab-versioning', '1.3.3' # 1.3.2 fails
+  s.add_dependency 'moab-versioning', '~> 1.4.0' # 1.3.2 fails
   s.add_dependency 'stanford-mods', '~> 0.0.14'
 
   # Bundler will install these gems too if you've checked out dor-services source from git and run 'bundle install'


### PR DESCRIPTION
This is required to get rake spec to pass on ruby 2.1.  Indeed, it is required to get rake spec to even run.  And seemingly, it was the _only_ thing required.  

Note: There is still a bunch of junk output during tests as previously described.
