### PR TITLE
ARGO-390:  add is_file_in_workspace?

### DIFF
--- a/lib/dor/models/contentable.rb
+++ b/lib/dor/models/contentable.rb
@@ -125,6 +125,7 @@ module Dor
       #remove the resource record from the metadata and renumber the resource sequence
       self.contentMetadata.remove_resource resource_name
     end
+
     #list files in the workspace
     def list_files
       filename='none'
@@ -147,6 +148,16 @@ module Dor
         end
       end
       return files
+    end
+
+    # determine whether the file in question is present in the object's workspace.
+    # note: for this method to work, the workspace must be mounted on the local file 
+    # system, and Config.dor_workspace_path must be set to point to the correct location.
+    def is_file_in_workspace? filename
+      druid_str = self.pid
+      dor_workspace_path = Config.dor_workspace_path
+      druid_obj = DruidTools::Druid.new(druid_str, dor_workspace_path)
+      return druid_obj.find_content(filename) != nil
     end
 
     # Appends contentMetadata file resources from the source objects to this object

--- a/lib/dor/models/contentable.rb
+++ b/lib/dor/models/contentable.rb
@@ -151,12 +151,8 @@ module Dor
     end
 
     # determine whether the file in question is present in the object's workspace.
-    # note: for this method to work, the workspace must be mounted on the local file 
-    # system, and Config.dor_workspace_path must be set to point to the correct location.
     def is_file_in_workspace? filename
-      druid_str = self.pid
-      dor_workspace_path = Config.dor_workspace_path
-      druid_obj = DruidTools::Druid.new(druid_str, dor_workspace_path)
+      druid_obj = DruidTools::Druid.new(self.pid, Dor::Config.stacks.local_workspace_root)
       return druid_obj.find_content(filename) != nil
     end
 

--- a/spec/dor/contentable_spec.rb
+++ b/spec/dor/contentable_spec.rb
@@ -154,6 +154,22 @@ describe Dor::Contentable do
       @item.remove_file('gw177fc7976_05_0001.jp2')
     end
   end
+  describe 'is_file_in_workspace?' do
+    it 'should return true if the file is in the workspace for the object' do
+      mock_filename = 'fake_file'
+      mock_druid_obj = double(DruidTools::Druid)
+      mock_druid_obj.stub(:find_content).with(mock_filename).and_return('this is not nil')
+      DruidTools::Druid.stub(:new).and_return(mock_druid_obj)
+      expect(@item.is_file_in_workspace?(mock_filename)).to eq(true)
+    end
+    it 'should return false if the file is not in the workspace for the object' do
+      mock_filename = 'fake_file'
+      mock_druid_obj = double(DruidTools::Druid)
+      mock_druid_obj.stub(:find_content).with(mock_filename).and_return(nil)
+      DruidTools::Druid.stub(:new).and_return(mock_druid_obj)
+      expect(@item.is_file_in_workspace?(mock_filename)).to eq(false)
+    end
+  end
 
   describe "#decomission" do
 


### PR DESCRIPTION
make it easier to robustly determine whether a given object has a given file in its workspace.  add corresponding unit tests.