### PR TITLE
Update presentable.rb

### DIFF
--- a/lib/dor/models/presentable.rb
+++ b/lib/dor/models/presentable.rb
@@ -32,6 +32,14 @@ module Dor
         '@id'   => "#{purl_base_uri}/iiif/manifest.json",
         'label' => lbl,
         'attribution' => 'Provided by the Stanford University Libraries',
+        'logo' => { 
+          '@id' => "http://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette/full/,400/0/default.jpg", 
+          'service' => { 
+            '@context' => "http://iiif.io/api/image/2/context.json", 
+            '@id' => "http://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette", 
+            'profile' => "http://iiif.io/api/image/2/level1.json" 
+            } 
+          },
         'seeAlso' => {
           '@id' => "#{purl_base_uri}.mods",
           'format' => 'application/mods+xml'

--- a/lib/dor/models/presentable.rb
+++ b/lib/dor/models/presentable.rb
@@ -33,7 +33,7 @@ module Dor
         'label' => lbl,
         'attribution' => 'Provided by the Stanford University Libraries',
         'logo' => { 
-          '@id' => "http://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette/full/,400/0/default.jpg", 
+          '@id' => "http://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette/full/400,/0/default.jpg", 
           'service' => { 
             '@context' => "http://iiif.io/api/image/2/context.json", 
             '@id' => "http://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette", 

--- a/spec/dor/presentable_spec.rb
+++ b/spec/dor/presentable_spec.rb
@@ -69,14 +69,14 @@ describe Dor::Presentable do
       "@type": "sc:Manifest",
       "label": "Roman Imperial denarius",
       "attribution": "(c) 2009 by Jasper Wilcox. All rights reserved.",
-      "logo" => { 
-          "@id" => "http://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette/full/,400/0/default.jpg", 
-          "service" => { 
-            "@context" => "http://iiif.io/api/image/2/context.json", 
-            "@id" => "http://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette", 
-            "profile" => "http://iiif.io/api/image/2/level1.json" 
-            } 
-          },
+      "logo": { 
+        "@id": "http://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette/full/,400/0/default.jpg", 
+        "service": { 
+          "@context": "http://iiif.io/api/image/2/context.json", 
+          "@id": "http://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette", 
+          "profile": "http://iiif.io/api/image/2/level1.json" 
+        } 
+      },
       "seeAlso": {
         "@id": "https://purl-dev.stanford.edu/bp778zp8790.mods",
         "format": "application/mods+xml"

--- a/spec/dor/presentable_spec.rb
+++ b/spec/dor/presentable_spec.rb
@@ -70,7 +70,7 @@ describe Dor::Presentable do
       "label": "Roman Imperial denarius",
       "attribution": "(c) 2009 by Jasper Wilcox. All rights reserved.",
       "logo": { 
-        "@id": "http://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette/full/,400/0/default.jpg", 
+        "@id": "http://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette/full/400,/0/default.jpg", 
         "service": { 
           "@context": "http://iiif.io/api/image/2/context.json", 
           "@id": "http://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette", 

--- a/spec/dor/presentable_spec.rb
+++ b/spec/dor/presentable_spec.rb
@@ -69,6 +69,14 @@ describe Dor::Presentable do
       "@type": "sc:Manifest",
       "label": "Roman Imperial denarius",
       "attribution": "(c) 2009 by Jasper Wilcox. All rights reserved.",
+      "logo" => { 
+          "@id" => "http://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette/full/,400/0/default.jpg", 
+          "service" => { 
+            "@context" => "http://iiif.io/api/image/2/context.json", 
+            "@id" => "http://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette", 
+            "profile" => "http://iiif.io/api/image/2/level1.json" 
+            } 
+          },
       "seeAlso": {
         "@id": "https://purl-dev.stanford.edu/bp778zp8790.mods",
         "format": "application/mods+xml"


### PR DESCRIPTION
adding in logo block. while not a requirement for IIIF spec compliance (this is an optional feature), this allows Mirador to call repository logo - allowing us to remove repo logos from the Mirador. 