### PR TITLE
use https for manifest.json logos for 5.x

### DIFF
--- a/lib/dor/models/presentable.rb
+++ b/lib/dor/models/presentable.rb
@@ -33,10 +33,10 @@ module Dor
         'label' => lbl,
         'attribution' => 'Provided by the Stanford University Libraries',
         'logo' => {
-          '@id' => "http://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette/full/400,/0/default.jpg",
+          '@id' => "https://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette/full/400,/0/default.jpg",
           'service' => {
             '@context' => "http://iiif.io/api/image/2/context.json",
-            '@id' => "http://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette",
+            '@id' => "https://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette",
             'profile' => "http://iiif.io/api/image/2/level1.json"
             }
           },

--- a/spec/dor/presentable_spec.rb
+++ b/spec/dor/presentable_spec.rb
@@ -70,10 +70,10 @@ describe Dor::Presentable do
       "label": "Roman Imperial denarius",
       "attribution": "(c) 2009 by Jasper Wilcox. All rights reserved.",
       "logo": {
-        "@id": "http://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette/full/400,/0/default.jpg",
+        "@id": "https://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette/full/400,/0/default.jpg",
         "service": {
           "@context": "http://iiif.io/api/image/2/context.json",
-          "@id": "http://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette",
+          "@id": "https://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette",
           "profile": "http://iiif.io/api/image/2/level1.json"
         }
       },


### PR DESCRIPTION
Sorry about the confusion. Here's the https logo changes for the 5.x branch. It's the same changes as for the 4.x branch in PR #78 