### PR TITLE
4.x: filter on MIME type image/jp2 for IIIF manifest files

### DIFF
--- a/lib/dor/models/presentable.rb
+++ b/lib/dor/models/presentable.rb
@@ -81,9 +81,9 @@ module Dor
       count = 0
       pub_obj_doc.xpath('/publicObject/contentMetadata/resource[@type="image" or @type="page"]').each do |res_node|
         count += 1
-        img_file_name = res_node.at_xpath('file/@id').text.split('.').first
-        height = res_node.at_xpath('file/imageData/@height').text.to_i
-        width = res_node.at_xpath('file/imageData/@width').text.to_i
+        img_file_name = res_node.at_xpath('file[@mimetype="image/jp2"]/@id').text.split('.').first
+        height = res_node.at_xpath('file[@mimetype="image/jp2"]/imageData/@height').text.to_i
+        width = res_node.at_xpath('file[@mimetype="image/jp2"]/imageData/@width').text.to_i
         stacks_uri = "#{Dor::Config.stacks.url}/image/iiif/#{id}%2F#{img_file_name}"
 
         canv = IIIF::Presentation::Canvas.new

--- a/spec/dor/presentable_spec.rb
+++ b/spec/dor/presentable_spec.rb
@@ -115,6 +115,7 @@ describe Dor::Presentable do
       <contentMetadata objectId="bp778zp8790" type="image">
         <resource id="bp778zp8790_1" sequence="1" type="image">
           <label>Image 1</label>
+          <file id="bp778zp8790_00_0001.pdf" mimetype="application/pdf" size="1234"/>
           <file id="bp778zp8790_00_0001.jp2" mimetype="image/jp2" size="132906">
             <imageData width="790" height="790"/>
           </file>


### PR DESCRIPTION
see JUMBO-28