### PR TITLE
4.x: add support for externalFile references for IIIF manifest generation

### DIFF
--- a/lib/dor/datastreams/content_metadata_ds.rb
+++ b/lib/dor/datastreams/content_metadata_ds.rb
@@ -35,10 +35,41 @@ module Dor
 
     def public_xml
       result = ng_xml.clone
-      result.xpath('/contentMetadata/resource[not(file[(@deliver="yes" or @publish="yes")])]'   ).each { |n| n.remove }
-      result.xpath('/contentMetadata/resource/file[not(@deliver="yes" or @publish="yes")]'      ).each { |n| n.remove }
-      result.xpath('/contentMetadata/resource/file').xpath('@preserve|@shelve|@publish|@deliver').each { |n| n.remove }
-      result.xpath('/contentMetadata/resource/file/checksum').each { |n| n.remove }
+      result.xpath('/contentMetadata/resource[not(file[(@deliver="yes" or @publish="yes")]|externalFile)]').each { |n| n.remove }
+      result.xpath('/contentMetadata/resource/file[not(@deliver="yes" or @publish="yes")]'                ).each { |n| n.remove }
+      result.xpath('/contentMetadata/resource/file').xpath('@preserve|@shelve|@publish|@deliver'          ).each { |n| n.remove }
+      result.xpath('/contentMetadata/resource/file/checksum'                                              ).each { |n| n.remove }
+      
+      # support for dereferencing links via externalFile element(s) to the source (child) item - see JUMBO-19
+      result.xpath('/contentMetadata/resource/externalFile').each do |externalFile|
+        # enforce pre-conditions that resourceId, objectId, fileId are required
+        src_resource_id = externalFile['resourceId']
+        src_druid = externalFile['objectId']
+        src_file_id = externalFile['fileId']
+        fail if src_resource_id.nil? || src_file_id.nil? || src_druid.nil?
+
+        # grab source item
+        src_item = Dor::Item.find(src_druid)
+        src_item_id = src_item.pid.split(':').last # strip druid: prefix
+
+        # locate and extract the resourceId/fileId elements
+        doc = src_item.datastreams['contentMetadata'].ng_xml
+        src_resource = doc.at_xpath("//resource[@id=\"#{externalFile['resourceId']}\"]")
+        src_file = src_resource.at_xpath("file[@id=\"#{externalFile['fileId']}\"]")
+        src_image_data = src_file.at_xpath('imageData')
+
+        # use title if label is not present
+        src_label = src_resource.at_xpath('label')
+        if src_label.nil?
+          src_label = doc.create_element('label')
+          src_label.content = src_item.datastreams['DC'].title.first unless src_item.datastreams['DC'].title.nil?
+        end
+
+        # add the extracted label and imageData
+        externalFile.add_previous_sibling(src_label)
+        externalFile << src_image_data unless src_image_data.nil?
+      end
+
       result
     end
 

--- a/lib/dor/datastreams/content_metadata_ds.rb
+++ b/lib/dor/datastreams/content_metadata_ds.rb
@@ -58,13 +58,10 @@ module Dor
         src_file = src_resource.at_xpath("file[@id=\"#{externalFile['fileId']}\"]")
         src_image_data = src_file.at_xpath('imageData')
 
-        # use title if label is not present
-        src_label = src_resource.at_xpath('label')
-        if src_label.nil?
-          src_label = doc.create_element('label')
-          src_label.content = src_item.datastreams['DC'].title.first unless src_item.datastreams['DC'].title.nil?
-        end
-
+        # always use title regardless of whether a child label is present
+        src_label = doc.create_element('label')
+        src_label.content = src_item.datastreams['DC'].title.first
+    
         # add the extracted label and imageData
         externalFile.add_previous_sibling(src_label)
         externalFile << src_image_data unless src_image_data.nil?

--- a/lib/dor/models/presentable.rb
+++ b/lib/dor/models/presentable.rb
@@ -82,19 +82,38 @@ module Dor
       count = 0
       pub_obj_doc.xpath('/publicObject/contentMetadata/resource[@type="image" or @type="page"]').each do |res_node|
         count += 1
-        img_file_name = res_node.at_xpath('file[@mimetype="image/jp2"]/@id').text.split('.').first
-        height = res_node.at_xpath('file[@mimetype="image/jp2"]/imageData/@height').text.to_i
-        width = res_node.at_xpath('file[@mimetype="image/jp2"]/imageData/@width').text.to_i
-        stacks_uri = "#{Dor::Config.stacks.url}/image/iiif/#{id}%2F#{img_file_name}"
+        
+        # if we have an external file for JP2000, build stack URLs to external resource images
+        if res_node.at_xpath('externalFile[@mimetype="image/jp2"]')
+          src_file_id = res_node.at_xpath('externalFile[@mimetype="image/jp2"]/@fileId').text.to_s
+          src_item_id = res_node.at_xpath('externalFile[@mimetype="image/jp2"]/@objectId').text.to_s.split(':').last # child item
+          src_image_data = res_node.at_xpath('externalFile[@mimetype="image/jp2"]/imageData')
+        else # otherwise grab from the file description
+          src_file_id = res_node.at_xpath('file[@mimetype="image/jp2"]/@id').text
+          src_item_id = id
+          src_image_data = res_node.at_xpath('file[@mimetype="image/jp2"]/imageData')
+        end
+        
+        #
+        # now extract metadata needed for canvases
+        #
+        
+        # determine the label, using a default of 'image'
+        label_text = 'image'
+        label_node = res_node.at_xpath('label')
+        label_text = label_node.text unless label_node.nil?
+
+        # construct the stacks URL to the image
+        img_file_name = src_file_id.split('.').first
+        stacks_uri = "#{Dor::Config.stacks.url}/image/iiif/#{src_item_id}%2F#{img_file_name}"
+        
+        # extract image dimensions for canvas
+        height = src_image_data['height'].to_i
+        width = src_image_data['width'].to_i
 
         canv = IIIF::Presentation::Canvas.new
         canv['@id'] = "#{purl_base_uri}/canvas/canvas-#{count}"
-        label_node = res_node.at_xpath('label')
-        if label_node
-          canv.label = label_node.text
-        else
-          canv.label = "image"
-        end
+        canv.label = label_text
         canv.height = height
         canv.width = width
 
@@ -116,8 +135,9 @@ module Dor
 
         # Use the first image to create a thumbnail on the manifest
         if count == 1
+          thumb_sz = 400
           thumb = IIIF::Presentation::Resource.new
-          thumb['@id'] = "#{stacks_uri}/full/400,/0/default.jpg"
+          thumb['@id'] = "#{stacks_uri}/full/#{thumb_sz},/0/default.jpg"
           thumb.service = svc
           manifest.thumbnail = thumb
         end

--- a/spec/dor/presentable_spec.rb
+++ b/spec/dor/presentable_spec.rb
@@ -4,6 +4,10 @@ class PresentableItem < ActiveFedora::Base
   include Dor::Presentable
 end
 
+class ItemizableItem < ActiveFedora::Base
+  include Dor::Itemizable
+end
+
 # Differences between objects will happen betweeen the incoming contentMetadata and DC, that's why they are set as variables in the
 # pub_xml template
 # Same for the canvas template
@@ -505,6 +509,26 @@ describe Dor::Presentable do
         item = PresentableItem.new(:pid => druid)
         pub_doc = Nokogiri::XML pub_xml
         expect(item.iiif_presentation_manifest_needed? pub_doc).to be true
+      end
+    end
+  end
+
+  context 'virtual objects' do
+    let(:druid) {'druid:hj097bm8879'}
+    
+    describe '#build_iiif_manifest' do
+      it 'transforms publicObject xml to a IIIF 2.0 Presentation manifest' do
+        @fixture_dir = File.join(File.dirname(__FILE__), '..', 'fixtures')
+        Dor::Config.push! do
+          stacks.document_cache_host 'purl.stanford.edu'
+          stacks.url 'https://stacks.stanford.edu'
+        end
+        
+        item = PresentableItem.new(:pid => druid)
+        pub_doc = Nokogiri::XML read_fixture("#{druid.split(':').last}_publicObject.xml")
+        
+        built_json = JSON.parse item.build_iiif_manifest(pub_doc)
+        expect(built_json).to eq(JSON.parse read_fixture("#{druid.split(':').last}_iiif_manifest.json"))
       end
     end
   end

--- a/spec/dor/publishable_spec.rb
+++ b/spec/dor/publishable_spec.rb
@@ -243,7 +243,7 @@ describe Dor::Publishable do
         correctContentMetadata = <<-EOXML
         <contentMetadata objectId="hj097bm8879" type="map">
          <resource id="hj097bm8879_1" sequence="1" type="image">
-           <label>Image 1</label>
+           <label>Cover: Carey's American atlas.</label>
            <externalFile fileId="2542A.jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1" mimetype="image/jp2">
              <imageData width="6475" height="4747"/>
            </externalFile>

--- a/spec/dor/publishable_spec.rb
+++ b/spec/dor/publishable_spec.rb
@@ -6,6 +6,10 @@ class PublishableItem < ActiveFedora::Base
   include Dor::Releaseable
 end
 
+class ItemizableItem < ActiveFedora::Base
+  include Dor::Itemizable
+end
+
 describe Dor::Publishable do
   before(:each) { stub_config   }
   after(:each)  { unstub_config }
@@ -233,6 +237,57 @@ describe Dor::Publishable do
           @item.publish_metadata
           expect(File).to_not exist(druid1.path)
         end
+      end
+      
+      it 'handles externalFile references' do
+        correctContentMetadata = <<-EOXML
+        <contentMetadata objectId="hj097bm8879" type="map">
+         <resource id="hj097bm8879_1" sequence="1" type="image">
+           <label>Image 1</label>
+           <externalFile fileId="2542A.jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1" mimetype="image/jp2">
+             <imageData width="6475" height="4747"/>
+           </externalFile>
+           <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
+         </resource>
+         <resource id="hj097bm8879_2" sequence="2" thumb="yes" type="image">
+           <label>Title Page: Carey's American atlas.</label>
+           <externalFile fileId="2542B.jp2" objectId="druid:jw923xn5254" resourceId="jw923xn5254_1" mimetype="image/jp2">
+             <imageData width="3139" height="4675"/>
+           </externalFile>
+           <relationship objectId="druid:jw923xn5254" type="alsoAvailableAs"/>
+         </resource>
+        </contentMetadata>        
+        EOXML
+               
+        @item.contentMetadata.content = <<-EOXML
+        <contentMetadata objectId="hj097bm8879" type="map">
+          <resource id="hj097bm8879_1" sequence="1" type="image">
+            <externalFile fileId="2542A.jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1" mimetype="image/jp2"/>
+            <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
+          </resource>
+          <resource id="hj097bm8879_2" sequence="2" thumb="yes" type="image">
+            <externalFile fileId="2542B.jp2" objectId="druid:jw923xn5254" resourceId="jw923xn5254_1" mimetype="image/jp2"/>
+            <relationship objectId="druid:jw923xn5254" type="alsoAvailableAs"/>
+          </resource>
+        </contentMetadata>        
+        EOXML
+        
+        # load stubs
+        %w(cg767mn6478 jw923xn5254).each do |child_druid|
+          ci = ItemizableItem.new(:pid => "druid:#{child_druid}")
+
+          dsid = 'contentMetadata'
+          ds = Dor::ContentMetadataDS.from_xml read_fixture("#{ci.pid.split(':').last}_#{dsid}.xml")
+          ci.datastreams[dsid] = ds
+
+          dsid = 'DC'
+          ci.datastreams['DC'] = ::SimpleDublinCoreDs.from_xml read_fixture("#{ci.pid.split(':').last}_#{dsid}.xml")
+          ci.label = ci.datastreams['DC'].title
+          allow(Dor::Item).to receive(:find).with(ci.pid).and_return(ci)
+        end
+        
+        p_xml = Nokogiri::XML(@item.public_xml)
+        expect(p_xml.at_xpath('/publicObject/contentMetadata').to_xml).to be_equivalent_to(correctContentMetadata)
       end
 
       context 'copies to the document cache' do

--- a/spec/fixtures/cg767mn6478_DC.xml
+++ b/spec/fixtures/cg767mn6478_DC.xml
@@ -1,0 +1,4 @@
+<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <dc:title>Cover: Carey's American atlas.</dc:title>
+  <dc:identifier>druid:cg767mn6478</dc:identifier>
+</oai_dc:dc>

--- a/spec/fixtures/cg767mn6478_contentMetadata.xml
+++ b/spec/fixtures/cg767mn6478_contentMetadata.xml
@@ -1,0 +1,15 @@
+<contentMetadata objectId="cg767mn6478" type="image">
+  <resource id="cg767mn6478_1" sequence="1" type="image">
+    <label>Image 1</label>
+    <file id="2542A.tif" preserve="yes" publish="no" shelve="no" mimetype="image/tiff" size="92217124">
+      <checksum type="md5">5b79c8570b7ef582735f912aa24ce5f2</checksum>
+      <checksum type="sha1">1f09f8796bfa67db97557f3de48a96c87b286d32</checksum>
+      <imageData width="6475" height="4747"/>
+    </file>
+    <file id="2542A.jp2" mimetype="image/jp2" size="5789764" preserve="no" publish="yes" shelve="yes">
+      <checksum type="md5">cd5ca5c4666cfd5ce0e9dc8c83461d7a</checksum>
+      <checksum type="sha1">39feed6ee1b734cab2d6a446e909a9fc7ac6fd01</checksum>
+      <imageData width="6475" height="4747"/>
+    </file>
+  </resource>
+</contentMetadata>

--- a/spec/fixtures/hj097bm8879_iiif_manifest.json
+++ b/spec/fixtures/hj097bm8879_iiif_manifest.json
@@ -100,7 +100,7 @@
                             }
                         }
                     ],
-                    "label": "Image 1",
+                    "label": "Cover: Carey's American atlas.",
                     "width": 6475
                 },
                 {
@@ -127,7 +127,7 @@
                             }
                         }
                     ],
-                    "label": "Image 1",
+                    "label": "Title Page: Carey's American atlas.",
                     "width": 3139
                 }
             ],

--- a/spec/fixtures/hj097bm8879_iiif_manifest.json
+++ b/spec/fixtures/hj097bm8879_iiif_manifest.json
@@ -1,0 +1,145 @@
+{
+    "@context": "http://iiif.io/api/presentation/2/context.json",
+    "@id": "https://purl.stanford.edu/hj097bm8879/iiif/manifest.json",
+    "@type": "sc:Manifest",
+    "attribution": "\nProperty rights reside with the repository, Copyright © Stanford University. Images may be reproduced or transmitted, but not for commercial use. For commercial use or commercial republication, contact rumseymapcenter@stanford.edu This work is licensed under a Creative Commons License. By downloading any images from this site, you agree to the terms of that license.\n",
+    "description": "\nFirst atlas of America printed in America. First edition. These maps were also published in Carey's American edition of Guthrie's Geography (1795) and most of the maps say \"engraved for Carey's American edition of Guthrie's Geography improved.\" The maps were again used for the 1796 edition of Carey's General Atlas, unchanged except for the Tennessee map, which is titled \"Tennassee State\" instead of \"Tennassee Government\" which is the title in both the American Atlas and the Guthrie Atlas -see Wheat and Brun, and has several counties delineated in the eastern part of the state which do not show in the 1795 edition of the map. NMM 480 (American Atlas) has \"Tennassee State\" indicating that Carey was not consistent. This atlas was the model for John Reid's American Atlas of 1796. This copy's maps have very strong impressions. Rebound quarter leather, marbled paper covered boards.\n",
+    "label": "\nCarey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]\n",
+    "logo": {
+        "@id": "https://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette/full/400,/0/default.jpg",
+        "service": {
+            "@context": "http://iiif.io/api/image/2/context.json",
+            "@id": "https://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette",
+            "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+    },
+    "metadata": [
+        {
+            "label": "Contributor",
+            "value": "Carey, Mathew."
+        },
+        {
+            "label": "Contributor",
+            "value": "Barker, W."
+        },
+        {
+            "label": "Contributor",
+            "value": "Doolittle, Amos."
+        },
+        {
+            "label": "Contributor",
+            "value": "Harris, Caleb  Harding."
+        },
+        {
+            "label": "Contributor",
+            "value": "Harrison, Junr."
+        },
+        {
+            "label": "Contributor",
+            "value": "Lewis, Samuel."
+        },
+        {
+            "label": "Contributor",
+            "value": "Scott, J.T."
+        },
+        {
+            "label": "Contributor",
+            "value": "Smith, Genl. D."
+        },
+        {
+            "label": "Contributor",
+            "value": "Smither, T."
+        },
+        {
+            "label": "Contributor",
+            "value": "Vallance."
+        },
+        {
+            "label": "Publisher",
+            "value": "Mathew Carey,"
+        },
+        {
+            "label": "Date",
+            "value": "1795"
+        },
+        {
+            "label": "Date",
+            "value": "1795."
+        }
+    ],
+    "seeAlso": {
+        "@id": "https://purl.stanford.edu/hj097bm8879.mods",
+        "format": "application/mods+xml"
+    },
+    "sequences": [
+        {
+            "@id": "https://purl.stanford.edu/hj097bm8879/sequence-1",
+            "@type": "sc:Sequence",
+            "canvases": [
+                {
+                    "@id": "https://purl.stanford.edu/hj097bm8879/canvas/canvas-1",
+                    "@type": "sc:Canvas",
+                    "height": 4747,
+                    "images": [
+                        {
+                            "@id": "https://purl.stanford.edu/hj097bm8879/imageanno/anno-1",
+                            "@type": "oa:Annotation",
+                            "motivation": "sc:painting",
+                            "on": "https://purl.stanford.edu/hj097bm8879/canvas/canvas-1",
+                            "resource": {
+                                "@id": "https://stacks.stanford.edu/image/iiif/cg767mn6478%2F2542A/full/full/0/default.jpg",
+                                "@type": "dcterms:Image",
+                                "format": "image/jpeg",
+                                "height": 4747,
+                                "service": {
+                                    "@context": "http://iiif.io/api/image/2/context.json",
+                                    "@id": "https://stacks.stanford.edu/image/iiif/cg767mn6478%2F2542A",
+                                    "profile": "http://iiif.io/api/image/2/level1.json"
+                                },
+                                "width": 6475
+                            }
+                        }
+                    ],
+                    "label": "Image 1",
+                    "width": 6475
+                },
+                {
+                    "@id": "https://purl.stanford.edu/hj097bm8879/canvas/canvas-2",
+                    "@type": "sc:Canvas",
+                    "height": 4675,
+                    "images": [
+                        {
+                            "@id": "https://purl.stanford.edu/hj097bm8879/imageanno/anno-2",
+                            "@type": "oa:Annotation",
+                            "motivation": "sc:painting",
+                            "on": "https://purl.stanford.edu/hj097bm8879/canvas/canvas-2",
+                            "resource": {
+                                "@id": "https://stacks.stanford.edu/image/iiif/jw923xn5254%2F2542B/full/full/0/default.jpg",
+                                "@type": "dcterms:Image",
+                                "format": "image/jpeg",
+                                "height": 4675,
+                                "service": {
+                                    "@context": "http://iiif.io/api/image/2/context.json",
+                                    "@id": "https://stacks.stanford.edu/image/iiif/jw923xn5254%2F2542B",
+                                    "profile": "http://iiif.io/api/image/2/level1.json"
+                                },
+                                "width": 3139
+                            }
+                        }
+                    ],
+                    "label": "Image 1",
+                    "width": 3139
+                }
+            ],
+            "label": "Current order"
+        }
+    ],
+    "thumbnail": {
+        "@id": "https://stacks.stanford.edu/image/iiif/cg767mn6478%2F2542A/full/400,/0/default.jpg",
+        "service": {
+            "@context": "http://iiif.io/api/image/2/context.json",
+            "@id": "https://stacks.stanford.edu/image/iiif/cg767mn6478%2F2542A",
+            "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+    }
+}

--- a/spec/fixtures/hj097bm8879_publicObject.xml
+++ b/spec/fixtures/hj097bm8879_publicObject.xml
@@ -13,14 +13,14 @@
 </identityMetadata>
 <contentMetadata objectId="hj097bm8879" type="map">
   <resource id="hj097bm8879_1" sequence="1" type="image">
-    <label>Image 1</label>
+    <label>Cover: Carey's American atlas.</label>
     <externalFile fileId="2542A.jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1" mimetype="image/jp2">
       <imageData width="6475" height="4747"/>
     </externalFile>
     <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
   </resource>
   <resource id="hj097bm8879_2" sequence="2" thumb="yes" type="image">
-    <label>Image 1</label>
+    <label>Title Page: Carey's American atlas.</label>
     <externalFile fileId="2542B.jp2" objectId="druid:jw923xn5254" resourceId="jw923xn5254_1" mimetype="image/jp2">
       <imageData width="3139" height="4675"/>
     </externalFile>

--- a/spec/fixtures/hj097bm8879_publicObject.xml
+++ b/spec/fixtures/hj097bm8879_publicObject.xml
@@ -1,0 +1,110 @@
+<publicObject id="druid:hj097bm8879" published="2015-09-09T13:33:17-07:00">
+<identityMetadata>
+<sourceId source="Rumsey">2542</sourceId>
+<objectId>druid:hj097bm8879</objectId>
+<objectCreator>DOR</objectCreator>
+<objectLabel>Rumsey Atlas 2542</objectLabel>
+<objectType>item</objectType>
+<otherId name="catkey">10449093</otherId>
+<otherId name="uuid">3526ef90-1f4b-11e5-b0dc-0050569b3c3c</otherId>
+<tag>Project : Rumsey : AtlasProto</tag>
+<tag>Remediated By : 4.21.0</tag>
+<release to="Searchworks">true</release>
+</identityMetadata>
+<contentMetadata objectId="hj097bm8879" type="map">
+  <resource id="hj097bm8879_1" sequence="1" type="image">
+    <label>Image 1</label>
+    <externalFile fileId="2542A.jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1" mimetype="image/jp2">
+      <imageData width="6475" height="4747"/>
+    </externalFile>
+    <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_2" sequence="2" thumb="yes" type="image">
+    <label>Image 1</label>
+    <externalFile fileId="2542B.jp2" objectId="druid:jw923xn5254" resourceId="jw923xn5254_1" mimetype="image/jp2">
+      <imageData width="3139" height="4675"/>
+    </externalFile>
+    <relationship objectId="druid:jw923xn5254" type="alsoAvailableAs"/>
+  </resource>
+</contentMetadata>
+<rightsMetadata>
+<copyright>
+<human type="copyright">
+Property rights reside with the repository, Copyright © Stanford University. Images may be reproduced or transmitted, but not for commercial use. For commercial use or commercial republication, contact rumseymapcenter@stanford.edu This work is licensed under a Creative Commons License. By downloading any images from this site, you agree to the terms of that license.
+</human>
+</copyright>
+<access type="discover">
+<machine>
+<world/>
+</machine>
+</access>
+<access type="read">
+<machine>
+<world/>
+</machine>
+</access>
+<use>
+<human type="useAndReproduction">
+To obtain permission to publish or reproduce commercially, please contact the Digital & Rare Map Librarian, David Rumsey Map Center at rumseymapcenter@stanford.edu.
+</human>
+</use>
+<use>
+<machine type="creativeCommons">by-nc-sa</machine>
+<human type="creativeCommons">
+Attribution Non-Commercial Share Alike 3.0 Unported
+</human>
+</use>
+</rightsMetadata>
+<rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description rdf:about="info:fedora/druid:hj097bm8879">
+<fedora:isMemberOf rdf:resource="info:fedora/druid:xh235dd9059"/>
+<fedora:isMemberOfCollection rdf:resource="info:fedora/druid:xh235dd9059"/>
+</rdf:Description>
+</rdf:RDF>
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+<dc:title>
+Carey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]
+</dc:title>
+<dc:contributor>Carey, Mathew.</dc:contributor>
+<dc:contributor>Barker, W.</dc:contributor>
+<dc:contributor>Doolittle, Amos.</dc:contributor>
+<dc:contributor>Harris, Caleb & Harding.</dc:contributor>
+<dc:contributor>Harrison, Junr.</dc:contributor>
+<dc:contributor>Lewis, Samuel.</dc:contributor>
+<dc:contributor>Scott, J.T.</dc:contributor>
+<dc:contributor>Smith, Genl. D.</dc:contributor>
+<dc:contributor>Smither, T.</dc:contributor>
+<dc:contributor>Vallance.</dc:contributor>
+<dc:type>map</dc:type>
+<dc:type>cartographic image</dc:type>
+<dc:type>Atlases.</dc:type>
+<dc:date>1795</dc:date>
+<dc:date>1795.</dc:date>
+<dc:publisher>Mathew Carey,</dc:publisher>
+<dc:language>eng</dc:language>
+<dc:format>1 atlas : 21 maps ; 37 x 24 cm</dc:format>
+<dc:format>cartographic material</dc:format>
+<dc:description>
+First atlas of America printed in America. First edition. These maps were also published in Carey's American edition of Guthrie's Geography (1795) and most of the maps say "engraved for Carey's American edition of Guthrie's Geography improved." The maps were again used for the 1796 edition of Carey's General Atlas, unchanged except for the Tennessee map, which is titled "Tennassee State" instead of "Tennassee Government" which is the title in both the American Atlas and the Guthrie Atlas -see Wheat and Brun, and has several counties delineated in the eastern part of the state which do not show in the 1795 edition of the map. NMM 480 (American Atlas) has "Tennassee State" indicating that Carey was not consistent. This atlas was the model for John Reid's American Atlas of 1796. This copy's maps have very strong impressions. Rebound quarter leather, marbled paper covered boards.
+</dc:description>
+<dc:description>National Atlas.</dc:description>
+<dc:description>References: P1172; Walsh p33; NMM 480; Howes C135.</dc:description>
+<dc:description type="local" displayLabel="Local note">Pub list no.: 2542.000.</dc:description>
+<dc:subject>Maps</dc:subject>
+<dc:coverage>Western Hemisphere</dc:coverage>
+<dc:coverage>North America</dc:coverage>
+<dc:coverage>South America</dc:coverage>
+<dc:coverage>United States</dc:coverage>
+<dc:coverage>Canada</dc:coverage>
+<dc:subject>G1100 1795 .C3 F</dc:subject>
+<dc:identifier>
+http://www.davidrumsey.com/luna/servlet/view/search?QuickSearchA=QuickSearchA&q=2542.000&sort=pub_list_no_initialsort%2Cpub_date%2Cpub_list_no%2Cseries_no&search=Search
+</dc:identifier>
+<dc:relation type="collection">
+David Rumsey Map Collection at Stanford University Libraries
+</dc:relation>
+</oai_dc:dc>
+<releaseData>
+<release to="Searchworks">true</release>
+</releaseData>
+</publicObject>

--- a/spec/fixtures/jw923xn5254_DC.xml
+++ b/spec/fixtures/jw923xn5254_DC.xml
@@ -1,0 +1,4 @@
+<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <dc:title>Title Page: Carey's American atlas.</dc:title>
+  <dc:identifier>druid:jw923xn5254</dc:identifier>
+</oai_dc:dc>

--- a/spec/fixtures/jw923xn5254_contentMetadata.xml
+++ b/spec/fixtures/jw923xn5254_contentMetadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <contentMetadata objectId="jw923xn5254" type="image">
   <resource id="jw923xn5254_1" sequence="1" type="image">
-    <!-- Test title copying by removing this label <label>Image 1</label> -->
+    <label>Image 1</label>
     <file id="2542B.tif" preserve="yes" publish="no" shelve="no" mimetype="image/tiff" size="44028890">
       <checksum type="md5">b5f6fcd6eb0ad02800aeb82cba6d0eed</checksum>
       <checksum type="sha1">a90aea983620238d8e1384d9a5cb683c6acd6984</checksum>

--- a/spec/fixtures/jw923xn5254_contentMetadata.xml
+++ b/spec/fixtures/jw923xn5254_contentMetadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<contentMetadata objectId="jw923xn5254" type="image">
+  <resource id="jw923xn5254_1" sequence="1" type="image">
+    <!-- Test title copying by removing this label <label>Image 1</label> -->
+    <file id="2542B.tif" preserve="yes" publish="no" shelve="no" mimetype="image/tiff" size="44028890">
+      <checksum type="md5">b5f6fcd6eb0ad02800aeb82cba6d0eed</checksum>
+      <checksum type="sha1">a90aea983620238d8e1384d9a5cb683c6acd6984</checksum>
+      <imageData width="3139" height="4675"/>
+    </file>
+    <file id="2542B.jp2" mimetype="image/jp2" size="2762668" preserve="no" publish="yes" shelve="yes">
+      <checksum type="md5">bccdbb2500bb139d6d622321bfd2aa57</checksum>
+      <checksum type="sha1">80454c111675ec7e2c425e909810c49a69ffef26</checksum>
+      <imageData width="3139" height="4675"/>
+    </file>
+  </resource>
+</contentMetadata>


### PR DESCRIPTION
This is a 4.x version of https://github.com/sul-dlss/dor-services/pull/85 from the 5.x branch. I deleted https://github.com/sul-dlss/dor-services/pull/85 in favor of this PR.