### PR TITLE
4.x: revise add_collection_reference to use location/url

### DIFF
--- a/lib/dor/models/describable.rb
+++ b/lib/dor/models/describable.rb
@@ -121,16 +121,21 @@ module Dor
         title_node = Nokogiri::XML::Node.new('title', doc)
         title_node.content = collection_title
 
-        id_node = Nokogiri::XML::Node.new('identifier', doc)
-        id_node['type'] = 'uri'
-        id_node.content = "http://#{Dor::Config.stacks.document_cache_host}/#{druid.split(':').last}"
+        # e.g., 
+        #   <location>
+        #     <url>http://purl.stanford.edu/rh056sr3313</url>
+        #   </location>
+        loc_node = doc.create_element('location')
+        url_node = doc.create_element('url')
+        url_node.content = "http://#{Dor::Config.stacks.document_cache_host}/#{druid.split(':').last}"
+        loc_node << url_node
 
         type_node = Nokogiri::XML::Node.new('typeOfResource', doc)
         type_node['collection'] = 'yes'
         doc.root.add_child(related_item_node)
         related_item_node.add_child(title_info_node)
         title_info_node.add_child(title_node)
-        related_item_node.add_child(id_node)
+        related_item_node.add_child(loc_node)
         related_item_node.add_child(type_node)
       end
     end

--- a/spec/dor/describable_spec.rb
+++ b/spec/dor/describable_spec.rb
@@ -306,7 +306,7 @@ describe Dor::Describable do
       collection_title=xml.search('//mods:relatedItem/mods:titleInfo/mods:title')
       collection_title.length.should ==1
       collection_title.first.content.should == 'complete works of Henry George'
-      collection_uri = xml.search('//mods:relatedItem/mods:identifier[@type="uri"]')
+      collection_uri = xml.search('//mods:relatedItem/mods:location/mods:url')
       expect(collection_uri.length).to eq(1)
       expect(collection_uri.first.content).to eq "http://purl.stanford.edu/zb871zd0767"
     end
@@ -326,7 +326,7 @@ describe Dor::Describable do
       collection_title=xml.search('//mods:relatedItem/mods:titleInfo/mods:title')
       collection_title.length.should ==1
       collection_title.first.content.should == 'complete works of Henry George'
-      collection_uri = xml.search('//mods:relatedItem/mods:identifier[@type="uri"]')
+      collection_uri = xml.search('//mods:relatedItem/mods:location/mods:url')
       expect(collection_uri.length).to eq(1)
       expect(collection_uri.first.content).to eq "http://purl.stanford.edu/zb871zd0767"
     end
@@ -442,7 +442,7 @@ describe Dor::Describable do
       expect(doc.xpath('//comment()').size).to eq 0
       collections      = doc.search('//mods:relatedItem/mods:typeOfResource[@collection=\'yes\']')
       collection_title = doc.search('//mods:relatedItem/mods:titleInfo/mods:title')
-      collection_uri   = doc.search('//mods:relatedItem/mods:identifier[@type="uri"]')
+      collection_uri   = doc.search('//mods:relatedItem/mods:location/mods:url')
       expect(collections.length     ).to eq 1
       expect(collection_title.length).to eq 1
       expect(collection_uri.length  ).to eq 1
@@ -473,7 +473,7 @@ describe Dor::Describable do
       collection_title=doc.search('//xmlns:relatedItem/xmlns:titleInfo/xmlns:title')
       collection_title.length.should ==1
       collection_title.first.content.should == 'complete works of Henry George'
-      collection_uri = doc.search('//xmlns:relatedItem/xmlns:identifier[@type="uri"]')
+      collection_uri = doc.search('//xmlns:relatedItem/xmlns:location/xmlns:url')
       expect(collection_uri.length).to eq(1)
       expect(collection_uri.first.content).to eq "http://purl.stanford.edu/zb871zd0767"
       expect(doc.xpath('//xmlns:accessCondition[@type="useAndReproduction"]').size).to eq(1)


### PR DESCRIPTION
rather than identifier type=uri. See LYBERSTRUCTURE-469 for details.

This is the 4.x version of https://github.com/sul-dlss/dor-services/pull/84 which is on 5.x. I deleted https://github.com/sul-dlss/dor-services/pull/84 in favor of this PR.