### PR TITLE
4.x: add virtual resource to contentMetadata

### DIFF
--- a/lib/dor/models/contentable.rb
+++ b/lib/dor/models/contentable.rb
@@ -222,5 +222,13 @@ module Dor
       rightsMetadata.content = '<rightsMetadata/>'
       add_tag "Decommissioned : #{tag}"
     end
+    
+    # Adds a RELS-EXT constituent relationship to the given druid
+    # @param [String] druid the parent druid of the constituent relationship
+    # e.g., 
+    #     <fedora:isConstituentOf rdf:resource="info:fedora/druid:hj097bm8879" />
+    def add_constituent(druid)
+      add_relationship :is_constituent_of, ActiveFedora::Base.find(druid)      
+    end
   end
 end

--- a/spec/dor/content_metadata_ds_spec.rb
+++ b/spec/dor/content_metadata_ds_spec.rb
@@ -235,5 +235,73 @@ describe Dor::ContentMetadataDS do
     it 'should read the stacks value' do
       @item.contentMetadata.stacks.should == ["/specialstack"]
     end
+  end
+  describe 'add_virtual_resource' do
+    it 'should add a virtual resource to the target child item' do
+      child_druid = 'bb273jy3359'
+      child_resource = Nokogiri::XML('
+      <resource type="image" sequence="1" id="bb273jy3359_1">
+        <label>Image 1</label>
+        <file preserve="yes" shelve="no" publish="no" id="00006672_0007.tif" mimetype="image/tiff" size="27469533">
+          <checksum type="md5">4e3bc269ab1fc5dc5a37cde75d220394</checksum>
+          <checksum type="sha1">63688070add0f246bffb1d9739a9d4c6b5e0e5ef</checksum>
+          <imageData width="3883" height="2907"/>
+        </file>
+        <file id="00006672_0007.jp2" mimetype="image/jp2" size="2124513" preserve="no" publish="yes" shelve="yes">
+          <checksum type="md5">65fad5e9dbaaef1130e500f6472a7200</checksum>
+          <checksum type="sha1">374d1b71522acf10bbe9fff6af5f50dd5de3022c</checksum>
+          <imageData width="3883" height="2907"/>
+        </file>
+      </resource>
+      ').root
+    
+      @item.contentMetadata.add_virtual_resource(child_druid, child_resource)
+      nodes = @item.contentMetadata.ng_xml.search('//resource[@id=\'ab123cd4567_2\']')
+      expect(nodes.length).to eq(1)
+      node = nodes.first
+      expect(node['id'      ]).to eq('ab123cd4567_2')
+      expect(node['type'    ]).to eq('image')
+      expect(node['sequence']).to eq('2')
+    
+      expect(nodes.search('label').length).to eq(0)
+
+      externalFile = nodes.search('externalFile')
+      expect(externalFile.length).to eq(1)
+      expect(externalFile.first['objectId']).to eq('bb273jy3359')
+      expect(externalFile.first['resourceId']).to eq('bb273jy3359_1')
+      expect(externalFile.first['fileId']).to eq('00006672_0007.jp2')
+      expect(externalFile.first['mimetype']).to eq('image/jp2')
+    
+      relationship = nodes.search('relationship')
+      expect(relationship.length).to eq(1)
+      expect(relationship.first['type']).to eq('alsoAvailableAs')
+      expect(relationship.first['objectId']).to eq('bb273jy3359')
     end
+
+    it 'should add a virtual resource to the target child item even if it has 2 published files' do
+      child_druid = 'bb273jy3359'
+      child_resource = Nokogiri::XML('
+      <resource type="image" sequence="1" id="bb273jy3359_1">
+        <label>Image 1</label>
+        <file preserve="yes" shelve="no" publish="yes" id="00006672_0007.tif" mimetype="image/tiff" size="27469533">
+          <checksum type="md5">4e3bc269ab1fc5dc5a37cde75d220394</checksum>
+          <checksum type="sha1">63688070add0f246bffb1d9739a9d4c6b5e0e5ef</checksum>
+          <imageData width="3883" height="2907"/>
+        </file>
+        <file id="00006672_0007.jp2" mimetype="image/jp2" size="2124513" preserve="no" publish="yes" shelve="yes">
+          <checksum type="md5">65fad5e9dbaaef1130e500f6472a7200</checksum>
+          <checksum type="sha1">374d1b71522acf10bbe9fff6af5f50dd5de3022c</checksum>
+          <imageData width="3883" height="2907"/>
+        </file>
+      </resource>
+      ').root
+  
+      @item.contentMetadata.add_virtual_resource(child_druid, child_resource)
+      nodes = @item.contentMetadata.ng_xml.search('//resource[@id=\'ab123cd4567_2\']')
+      externalFile = nodes.search('externalFile')
+      expect(externalFile.length).to eq(2)
+      expect(externalFile[0]['mimetype']).to eq('image/tiff')
+      expect(externalFile[1]['mimetype']).to eq('image/jp2')
+    end
+  end
 end

--- a/spec/dor/contentable_spec.rb
+++ b/spec/dor/contentable_spec.rb
@@ -196,4 +196,24 @@ describe Dor::Contentable do
       expect(obj.identityMetadata.tags).to include('Decommissioned : test')
     end
   end
+
+  describe '#add_constituent' do
+    let(:obj) { Dor::Item.new }
+    
+    let(:child_obj) do
+      node = SpecNode.new
+      allow(node).to receive(:rels_ext).and_return(double('rels_ext', :content_will_change! => true, :content=>''))
+      node.pid = 'druid:aa111bb2222'
+      node
+    end
+    
+    before(:each) do
+      allow(ActiveFedora::Base).to receive(:find) { child_obj }
+    end
+    
+    it 'adds an isConstituentOf relationship from the object to the parent druid' do
+      obj.add_constituent('druid:aa111bb2222')
+      expect(obj.relationships(:is_constituent_of)).to eq(['info:fedora/druid:aa111bb2222'])
+    end
+  end
 end


### PR DESCRIPTION
This is the 4.x version of https://github.com/sul-dlss/dor-services/pull/79 which is on the 5.x branch. I closed https://github.com/sul-dlss/dor-services/pull/79 in favor of this PR.

See JUMBO-17 and the related PR sul-dlss/dor-utils#4