### PR TITLE
keep Releaseable#to_solr from hitting PURL

### DIFF
--- a/lib/dor/models/releaseable.rb
+++ b/lib/dor/models/releaseable.rb
@@ -37,8 +37,9 @@ module Dor
     end
 
     # Determine which projects an item is released for
+    # @param [Boolean] skip_live_purl set true to skip requesting from purl backend
     # @return [Hash{String => Boolean}] all namespaces, keys are Project name Strings, values are Boolean
-    def released_for
+    def released_for(skip_live_purl = false)
       released_hash = {}
       # Get release tags on the item itself
       release_tags_on_this_item = release_nodes
@@ -63,13 +64,14 @@ module Dor
       # In a nil case, the lack of an explicit false tag we do nothing.
       (potential_applicable_release_tags.keys - released_hash.keys).each do |key|  # don't bother checking if already added to the release hash, they were added due to a self tag so that has won
         latest_applicable_tag_for_key = latest_applicable_release_tag_in_array(potential_applicable_release_tags[key], administrative_tags)
-        unless latest_applicable_tag_for_key.nil? # We have a valid tag, record it
-          released_hash[key] = clean_release_tag_for_purl(latest_applicable_tag_for_key)
-        end
+        next if latest_applicable_tag_for_key.nil? # We have a valid tag, record it
+        released_hash[key] = clean_release_tag_for_purl(latest_applicable_tag_for_key)
       end
 
       # See what the application is currently released for on Purl.  If something is released in purl but not listed here, it needs to be added as a false
-      add_tags_from_purl(released_hash)
+      add_tags_from_purl(released_hash) unless skip_live_purl
+
+      released_hash
     end
 
     # Take a hash of tags as obtained via Dor::Item.release_tags and returns all self tags
@@ -356,7 +358,7 @@ module Dor
 
       # TODO: sort of worried about the performance impact in bulk reindex
       # situations, since released_for recurses all parent collections.  jmartin 2015-07-14
-      released_for().each { |key, val|
+      released_for(true).each { |key, val|
         add_solr_value(solr_doc, 'released_to', key, :symbol, []) if val
       }
 

--- a/spec/dor/embargoable_spec.rb
+++ b/spec/dor/embargoable_spec.rb
@@ -46,22 +46,12 @@ describe Dor::Embargoable do
     EOXML
   }
 
-  before :all do
-    @fixture_dir = fixture_dir = File.join(File.dirname(__FILE__), '../fixtures')
-    Dor::Config.push! do
-      suri.mint_ids false
-      gsearch.url 'http://solr.edu/gsearch'
-      solrizer.url 'http://solr.edu/solrizer'
-      fedora.url 'http://fedora.edu'
-      stacks.local_workspace_root File.join(fixture_dir, 'workspace')
-    end
-
-    # ActiveFedora::SolrService.register(Dor::Config.gsearch.url)
-    # Fedora::Repository.register(Dor::Config.fedora.url)
+  before :each do
+    stub_config
   end
 
-  after :all do
-    Dor::Config.pop!
+  after :each do
+    unstub_config
   end
 
   before(:each) do

--- a/spec/dor/releaseable_spec.rb
+++ b/spec/dor/releaseable_spec.rb
@@ -19,9 +19,8 @@ describe Dor::Releaseable, :vcr do
       @bryar_trans_am       = Dor::Item.find(@bryar_trans_am_druid)
       @bryar_trans_am_admin_tags   = @bryar_trans_am.tags
       @bryar_trans_am_release_tags = @bryar_trans_am.release_nodes
-      @array_of_times = [Time.parse('2015-01-06 23:33:47Z'), Time.parse('2015-01-07 23:33:47Z'), Time.parse('2015-01-08 23:33:47Z'), Time.parse('2015-01-09 23:33:47Z')].map(&:iso8601)
+      @array_of_times = ['2015-01-06 23:33:47Z', '2015-01-07 23:33:47Z', '2015-01-08 23:33:47Z', '2015-01-09 23:33:47Z'].map{ |x| Time.parse(x).iso8601 }
     end
-
   end
 
   after :each do
@@ -183,13 +182,13 @@ describe Dor::Releaseable, :vcr do
         VCR.use_cassette('releaseable_release_xml') do
           item = Dor::Item.find('druid:dc235vd9662')
           release_xml = item.generate_release_xml
-          expect(release_xml.class).to eq(String)
+          expect(release_xml).to be_a(String)
           true_or_false = %w(true false)
           xml_obj = Nokogiri(release_xml)
           xml_obj.xpath('//release').each do |release_node|
             expect(release_node.name).to eq('release') # Well, duh
             expect(release_node.attributes.keys).to eq(['to'])
-            expect(release_node.attributes['to'].value.class).to eq(String)
+            expect(release_node.attributes['to'].value).to be_a(String)
             expect(true_or_false.include? release_node.children.text).to be_truthy
           end
         end
@@ -286,7 +285,7 @@ describe 'Adding release nodes', :vcr do
          expect(@item.add_release_node(true, @args.merge(:what => 'self'))).to be_a_kind_of(Nokogiri::XML::Element)
       end
     end
-      it 'should fail to add a release node when there is an attribute error' do
+    it 'should fail to add a release node when there is an attribute error' do
       VCR.use_cassette('simple_release_tag_add_failure_test') do
          expect{@item.add_release_node(true,  {:who => nil, :to => 'Revs', :what => 'self', :tag => 'Project:Fitch:Batch2'})}.to raise_error(ArgumentError)
          expect{@item.add_release_node(false, @args.merge(:tag => 'Project'))}.to raise_error(ArgumentError)
@@ -339,16 +338,16 @@ describe 'Adding release nodes', :vcr do
     it 'should get the purl xml for a druid' do
       VCR.use_cassette('fetch_purl_test_xml') do
         x = @item.get_xml_from_purl
-        expect(x.class).to eq(Nokogiri::HTML::Document)
+        expect(x).to be_a(Nokogiri::HTML::Document)
         expect(x.at_xpath('//html/body/publicobject').attr('id')).to eq(@item.id)
       end
     end
 
     it 'should not raise an error for a 404 when attempted to obtain a purl' do
       VCR.use_cassette('purl_404') do
-        #expect(Time).to receive(:now).and_return(@now).at_least(:once)
+        expect(Dor.logger).to receive(:warn).once
         expect(@item).to receive(:id).and_return('druid:IAmABadDruid').at_least(:once)
-        expect(@item.get_xml_from_purl.class).to eq(Nokogiri::HTML::Document)
+        expect(@item.get_xml_from_purl).to be_a(Nokogiri::HTML::Document)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,7 +45,7 @@ module Dor::SpecHelpers
       sdr.local_workspace_root         File.join(fixture_dir, 'workspace')
       sdr.local_export_home            File.join(fixture_dir, 'export')
     end
-    allow(ActiveFedora).to receive(:fedora).and_return(double('frepo').as_null_object)
+    allow(ActiveFedora).to receive(:fedora).and_return(double('frepo').as_null_object)  # must be used in per-request context: :each not :all
   end
 
   def unstub_config


### PR DESCRIPTION
add an option to released_for that optionally omits the call to add_tags_from_purl.  default the new option to false (i.e. default to old behavior).  have to_solr call released_for(true) so that no request to PURL is made as part of solrization.

@lmcglohon @atz : is this something we'd want to backport to 4.x?

explanation for why this is being done:  lynn says we don't care about what actually lives on PURL when solrizing, just where we think the object should be released to according to its fedora data.  this fix allows solrization of objects that might have bad data in PURL (or which might live on instances without a corresponding PURL instance).  as such, it prevents some solrization errors, and when using this version of dor-services, argo's fixtures all load without a problem.  when argo's fixtures load without issue, argo's unit tests complete successfully.