### PR TITLE
Specify simplecov without platform

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :development do
 end
 
 group :development, :test do
-  gem 'simplecov',  :platform => [:ruby_19, :ruby_20, :ruby_21, :ruby_22]
+  gem 'simplecov'
 end
 
 group :test do


### PR DESCRIPTION
Instead of a full revert (since we want to include 2.2 in .travis.yml and the development dependency doesn't affect anyone).