### PR TITLE
correct path for machine readable use licence codes

### DIFF
--- a/lib/dor/datastreams/default_object_rights_ds.rb
+++ b/lib/dor/datastreams/default_object_rights_ds.rb
@@ -11,11 +11,11 @@ module Dor
         t.human
       end
 
-      t.creative_commons :path => '/use/machine', :type => 'creativeCommons' do
+      t.creative_commons :path => '/use/machine[@type=\'creativeCommons\']', :type => 'creativeCommons' do
         t.uri :path => '@uri'
       end
       t.creative_commons_human :path => '/use/human[@type=\'creativeCommons\']'
-      t.open_data_commons :path => '/use/machine', :type => 'openDataCommons' do
+      t.open_data_commons :path => '/use/machine[@type=\'openDataCommons\']', :type => 'openDataCommons' do
         t.uri :path => '@uri'
       end
       t.open_data_commons_human :path => '/use/human[@type=\'openDataCommons\']'

--- a/lib/dor/datastreams/rights_metadata_ds.rb
+++ b/lib/dor/datastreams/rights_metadata_ds.rb
@@ -20,11 +20,11 @@ module Dor
         t.human
       end
 
-      t.creative_commons :path => '/use/machine', :type => 'creativeCommons' do
+      t.creative_commons :path => '/use/machine[@type=\'creativeCommons\']', :type => 'creativeCommons' do
         t.uri :path => '@uri'
       end
       t.creative_commons_human :path => '/use/human[@type=\'creativeCommons\']'
-      t.open_data_commons :path => '/use/machine', :type => 'openDataCommons' do
+      t.open_data_commons :path => '/use/machine[@type=\'openDataCommons\']', :type => 'openDataCommons' do
         t.uri :path => '@uri'
       end
       t.open_data_commons_human :path => '/use/human[@type=\'openDataCommons\']'

--- a/spec/dor/editable_spec.rb
+++ b/spec/dor/editable_spec.rb
@@ -165,7 +165,9 @@ describe Dor::Editable do
       expect(@empty_item.use_license).to eq(use_license_machine)
       expect(@empty_item.use_license_uri).to eq(use_license_uri)
       expect(@empty_item.use_license_human).to eq(use_license_human)
+      expect(@empty_item.creative_commons_license).to eq(use_license_machine)
       expect(@empty_item.creative_commons_license_human).to eq(use_license_human)
+      expect(@empty_item.open_data_commons_license).to eq('')
       expect(@empty_item.open_data_commons_license_human).to eq('')
     end
     it 'should set the machine and human readable ODC licenses given the right license code' do
@@ -174,7 +176,9 @@ describe Dor::Editable do
       @empty_item.use_license = use_license_machine
       expect(@empty_item.use_license).to eq(use_license_machine)
       expect(@empty_item.use_license_human).to eq(use_license_human)
+      expect(@empty_item.creative_commons_license).to eq('')
       expect(@empty_item.creative_commons_license_human).to eq('')
+      expect(@empty_item.open_data_commons_license).to eq(use_license_machine)
       expect(@empty_item.open_data_commons_license_human).to eq(use_license_human)
     end
     it 'should throw an exception if no valid license code is given' do


### PR DESCRIPTION
This PR makes the terminology read paths for the DefaultObjectRightsDS and RightsMetadataDS more specific to pick out the correct license in the case of 2 use licenses and added tests for RightsMetadataDS for those cases.