### PR TITLE
add ability to refresh cached version of workflows datastream

### DIFF
--- a/lib/dor/datastreams/workflow_ds.rb
+++ b/lib/dor/datastreams/workflow_ds.rb
@@ -36,7 +36,11 @@ module Dor
       @ng_xml ||= Nokogiri::XML::Document.parse(content)
     end
 
-    def content
+    # @param [Boolean] refresh The WorkflowDS caches the content retrieved from the workflow
+    # service. This flag will invalidate the cached content and refetch it from the workflow
+    # service directly
+    def content(refresh = false)
+      @content = nil if refresh
       @content ||= Dor::WorkflowService.get_workflow_xml 'dor', pid, nil
     rescue RestClient::ResourceNotFound
       xml = Nokogiri::XML(%(<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<workflows objectId="#{pid}"/>))

--- a/lib/dor/models/processable.rb
+++ b/lib/dor/models/processable.rb
@@ -211,11 +211,17 @@ module Dor
     # @param [String] name of the workflow to be initialized
     # @param [Boolean] create_ds create a 'workflows' datastream in Fedora for the object
     # @param [Integer] priority the workflow's priority level
-    def initialize_workflow(name, create_ds = true, priority = 0)
+    def create_workflow(name, create_ds = true, priority = 0)
       priority = workflows.current_priority if priority == 0
       opts = { :create_ds => create_ds, :lane_id => default_workflow_lane }
       opts[:priority] = priority if priority > 0
       Dor::WorkflowService.create_workflow(Dor::WorkflowObject.initial_repo(name), pid, name, Dor::WorkflowObject.initial_workflow(name), opts)
+      workflows.content(true) # refresh the copy of the workflows datastream
+    end
+
+    def initialize_workflow(name, create_ds = true, priority = 0)
+      warn 'WARNING: initialize_workflow is deprecated, use create_workflow instead'
+      create_workflow(name, create_ds, priority)
     end
 
     private


### PR DESCRIPTION
Fixes #111 

The `Dor::Item` object caches the XML for the workflows data stream. I've added the ability to refresh the cached XML from the workflow service using `item.workflows.content(true)`. I've also changed `create_workflow` (the new name for the deprecated `initialize_workflow`) so that after it calls the workflow service to create a new workflow, it refreshes the cache. I added unit tests for the cache invalidation logic.

@atz @jmartin-sul please review