### PR TITLE
No longer need to pin addressable

### DIFF
--- a/dor-services.gemspec
+++ b/dor-services.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'uuidtools', '~> 2.1.4'
   # s.add_dependency 'validatable', '~> 1.6.7'
   s.add_dependency 'osullivan', '~> 0.0.3'
-  s.add_dependency 'addressable', '2.3.5'  # lock to workaround frozen Addressable::URI runtime errors
   s.add_dependency 'retries'
 
   # Stanford dependencies


### PR DESCRIPTION
it causes webmock to pin to an old version from early 2014. the `rdf` gem used to include it but no longer does