### PR TITLE
index use_license_machine from rightsMetadata

### DIFF
--- a/lib/dor/datastreams/rights_metadata_ds.rb
+++ b/lib/dor/datastreams/rights_metadata_ds.rb
@@ -30,20 +30,6 @@ module Dor
       t.open_data_commons_human :path => '/use/human[@type=\'openDataCommons\']'
     end
 
-    define_template :creative_commons do |xml|
-      xml.use {
-        xml.human(:type => 'creativeCommons')
-        xml.machine(:type => 'creativeCommons', :uri => '')
-      }
-    end
-
-    define_template :open_data_commons do |xml|
-      xml.use {
-        xml.human(:type => 'openDataCommons')
-        xml.machine(:type => 'openDataCommons', :uri => '')
-      }
-    end
-
     def self.xml_template
       Nokogiri::XML::Builder.new do |xml|
         xml.rightsMetadata {
@@ -119,7 +105,15 @@ module Dor
       %w(use_statement_ssim copyright_ssim).each do |key|
         solr_doc[key] = solr_doc[key].reject { |val| val.nil? || val == '' }.flatten unless solr_doc[key].nil?
       end
+      add_solr_value(solr_doc, 'use_license_machine', use_license, :string, [:stored_sortable])
+      
       solr_doc
+    end
+
+    def use_license
+      return creative_commons unless ['', nil].include?(creative_commons)
+      return open_data_commons unless ['', nil].include?(open_data_commons)
+      ''
     end
 
   end # class

--- a/lib/dor/models/editable.rb
+++ b/lib/dor/models/editable.rb
@@ -49,7 +49,7 @@ module Dor
       super(solr_doc, *args)
       add_solr_value(solr_doc, 'default_rights', default_rights, :string, [:symbol])
       add_solr_value(solr_doc, 'agreement', agreement, :string, [:symbol]) if agreement_object
-      add_solr_value(solr_doc, 'use_license_machine', use_license, :string, [:stored_sortable])
+      add_solr_value(solr_doc, 'default_use_license_machine', use_license, :string, [:stored_sortable])
       solr_doc
     end
 

--- a/spec/dor/editable_spec.rb
+++ b/spec/dor/editable_spec.rb
@@ -4,27 +4,18 @@ describe Dor::Editable do
   before(:each) { stub_config   }
   after(:each)  { unstub_config }
   before :each do
-    @item = instantiate_fixture('druid_zt570tx3016', Dor::AdminPolicyObject)
+    @apo = instantiate_fixture('druid_zt570tx3016', Dor::AdminPolicyObject)
     @empty_item = instantiate_fixture('pw570tx3016', Dor::AdminPolicyObject)
   end
 
-  let(:mock_agreement) {
-    agr = Dor::Item.new
-    allow(agr).to receive(:new?).and_return false
-    allow(agr).to receive(:new_record?).and_return false
-    allow(agr).to receive(:pid).and_return 'druid:new_agreement'
-    allow(agr).to receive(:save)
-    agr
-  }
-
   describe 'add_roleplayer' do
     it 'should add a role' do
-      @item.add_roleplayer('dor-apo-manager', 'dlss:some-staff')
-      expect(@item.roles).to eq({'dor-apo-manager' => ['workgroup:dlss:developers', 'workgroup:dlss:pmag-staff', 'workgroup:dlss:smpl-staff', 'workgroup:dlss:dpg-staff', 'workgroup:dlss:argo-access-spec', 'sunetid:lmcrae', 'workgroup:dlss:some-staff']})
+      @apo.add_roleplayer('dor-apo-manager', 'dlss:some-staff')
+      expect(@apo.roles).to eq({'dor-apo-manager' => ['workgroup:dlss:developers', 'workgroup:dlss:pmag-staff', 'workgroup:dlss:smpl-staff', 'workgroup:dlss:dpg-staff', 'workgroup:dlss:argo-access-spec', 'sunetid:lmcrae', 'workgroup:dlss:some-staff']})
     end
 
     it 'should create a new role' do
-      @item.add_roleplayer('dor-apo-viewer', 'dlss:some-staff')
+      @apo.add_roleplayer('dor-apo-viewer', 'dlss:some-staff')
       {'dor-apo-manager' => ['workgroup:dlss:developers', 'workgroup:dlss:pmag-staff', 'workgroup:dlss:smpl-staff', 'workgroup:dlss:dpg-staff', 'workgroup:dlss:argo-access-spec', 'sunetid:lmcrae'], 'dor-apo-viewer' => ['workgroup:dlss:some-staff']}
     end
 
@@ -36,7 +27,7 @@ describe Dor::Editable do
 
   describe 'default_collections' do
     it 'should fetch the default collections' do
-      expect(@item.default_collections).to eq(['druid:fz306fj8334'])
+      expect(@apo.default_collections).to eq(['druid:fz306fj8334'])
     end
     it 'should not fail on an item with an empty datastream' do
       expect(@empty_item.default_collections).to eq([])
@@ -44,8 +35,8 @@ describe Dor::Editable do
   end
   describe 'add_default_collection' do
     it 'should set the collection values' do
-      @item.add_default_collection 'druid:fz306fj8335'
-      expect(@item.default_collections).to eq ['druid:fz306fj8334', 'druid:fz306fj8335']
+      @apo.add_default_collection 'druid:fz306fj8335'
+      expect(@apo.default_collections).to eq ['druid:fz306fj8334', 'druid:fz306fj8335']
     end
     it 'should work for empty datastreams' do
       @empty_item.add_default_collection 'druid:fz306fj8335'
@@ -54,8 +45,8 @@ describe Dor::Editable do
   end
   describe 'remove_default_collection' do
     it 'should remove the collection' do
-      @item.remove_default_collection 'druid:fz306fj8334'
-      expect(@item.default_collections).to eq([])
+      @apo.remove_default_collection 'druid:fz306fj8334'
+      expect(@apo.default_collections).to eq([])
     end
     it 'should work on an empty datastream' do
       @empty_item.add_default_collection 'druid:fz306fj8335'
@@ -65,7 +56,7 @@ describe Dor::Editable do
   end
   describe 'roles' do
     it 'should create a roles hash' do
-      expect(@item.roles).to eq({'dor-apo-manager' => ['workgroup:dlss:developers', 'workgroup:dlss:pmag-staff', 'workgroup:dlss:smpl-staff', 'workgroup:dlss:dpg-staff', 'workgroup:dlss:argo-access-spec', 'sunetid:lmcrae']})
+      expect(@apo.roles).to eq({'dor-apo-manager' => ['workgroup:dlss:developers', 'workgroup:dlss:pmag-staff', 'workgroup:dlss:smpl-staff', 'workgroup:dlss:dpg-staff', 'workgroup:dlss:argo-access-spec', 'sunetid:lmcrae']})
     end
     it 'should not fail on an item with an empty datastream' do
       expect(@empty_item.roles).to eq({})
@@ -73,7 +64,7 @@ describe Dor::Editable do
   end
   describe 'use_statement' do
     it 'should find the use statement' do
-      expect(@item.use_statement).to eq('Rights are owned by Stanford University Libraries. All Rights Reserved. This work is protected by copyright law. No part of the materials may be derived, copied, photocopied, reproduced, translated or reduced to any electronic medium or machine readable form, in whole or in part, without specific permission from the copyright holder. To access this content or to request reproduction permission, please send a written request to speccollref@stanford.edu.')
+      expect(@apo.use_statement).to eq('Rights are owned by Stanford University Libraries. All Rights Reserved. This work is protected by copyright law. No part of the materials may be derived, copied, photocopied, reproduced, translated or reduced to any electronic medium or machine readable form, in whole or in part, without specific permission from the copyright holder. To access this content or to request reproduction permission, please send a written request to speccollref@stanford.edu.')
     end
     it 'should not fail on an item with an empty datastream' do
       expect(@empty_item.use_statement).to eq('')
@@ -82,25 +73,25 @@ describe Dor::Editable do
 
   describe 'use_statement=' do
     it 'should assign use statement' do
-      @item.use_statement = 'hi'
-      expect(@item.use_statement).to eq('hi')
+      @apo.use_statement = 'hi'
+      expect(@apo.use_statement).to eq('hi')
     end
     it 'should assign null use statements' do
       ['  ', nil].each do |v|
-        @item.use_statement = v
-        expect(@item.use_statement).to be_nil
-        expect(@item.defaultObjectRights.ng_xml.at_xpath('/rightsMetadata/use/human[@type="useAndReproduction"]')).to be_nil
+        @apo.use_statement = v
+        expect(@apo.use_statement).to be_nil
+        expect(@apo.defaultObjectRights.ng_xml.at_xpath('/rightsMetadata/use/human[@type="useAndReproduction"]')).to be_nil
       end
     end
     it 'should fail if trying to set use statement after it is null' do
-      @item.use_statement = nil
-      expect { @item.use_statement = 'force fail' }.not_to raise_error
+      @apo.use_statement = nil
+      expect { @apo.use_statement = 'force fail' }.not_to raise_error
     end
   end
 
   describe 'copyright_statement' do
     it 'should find the copyright statement' do
-      expect(@item.copyright_statement).to eq('Additional copyright info')
+      expect(@apo.copyright_statement).to eq('Additional copyright info')
     end
     it 'should not fail on an item with an empty datastream' do
       expect(@empty_item.copyright_statement).to eq('')
@@ -108,31 +99,31 @@ describe Dor::Editable do
   end
   describe 'copyright_statement =' do
     it 'should assign copyright' do
-      @item.copyright_statement = 'hi'
-      expect(@item.copyright_statement).to eq('hi')
-      doc = Nokogiri::XML(@item.defaultObjectRights.content)
+      @apo.copyright_statement = 'hi'
+      expect(@apo.copyright_statement).to eq('hi')
+      doc = Nokogiri::XML(@apo.defaultObjectRights.content)
       expect(doc.at_xpath('/rightsMetadata/copyright/human[@type="copyright"]').text).to eq('hi')
     end
     it 'should assign null copyright' do
-      @item.copyright_statement = nil
-      expect(@item.copyright_statement).to be_nil
-      doc = Nokogiri::XML(@item.defaultObjectRights.content)
+      @apo.copyright_statement = nil
+      expect(@apo.copyright_statement).to be_nil
+      doc = Nokogiri::XML(@apo.defaultObjectRights.content)
       expect(doc.at_xpath('/rightsMetadata/copyright')).to be_nil
       expect(doc.at_xpath('/rightsMetadata/copyright/human[@type="copyright"]')).to be_nil
     end
     it 'should assign blank copyright' do
-      @item.copyright_statement = ' '
-      expect(@item.copyright_statement).to be_nil
+      @apo.copyright_statement = ' '
+      expect(@apo.copyright_statement).to be_nil
     end
     it 'should error if assigning copyright after removing one' do
-      @item.copyright_statement = nil
-      @item.copyright_statement = nil # call twice to ensure repeatability
-      expect { @item.copyright_statement = 'will fail' }.not_to raise_error
+      @apo.copyright_statement = nil
+      @apo.copyright_statement = nil # call twice to ensure repeatability
+      expect { @apo.copyright_statement = 'will fail' }.not_to raise_error
     end
   end
   describe 'metadata_source' do
     it 'should get the metadata source' do
-      expect(@item.metadata_source).to eq('MDToolkit')
+      expect(@apo.metadata_source).to eq('MDToolkit')
     end
     it 'should get nil for an empty datastream' do
       expect(@empty_item.metadata_source).to eq(nil)
@@ -140,8 +131,8 @@ describe Dor::Editable do
   end
   describe 'metadata_source=' do
     it 'should set the metadata source' do
-      @item.metadata_source = 'Symphony'
-      expect(@item.metadata_source).to eq('Symphony')
+      @apo.metadata_source = 'Symphony'
+      expect(@apo.metadata_source).to eq('Symphony')
     end
     it 'should set the metadata source for an empty datastream' do
       @empty_item.desc_metadata_format = 'TEI'
@@ -151,7 +142,7 @@ describe Dor::Editable do
   end
   describe 'creative_commons_license' do
     it 'should find the creative commons license' do
-      expect(@item.creative_commons_license).to eq('by-nc-sa')
+      expect(@apo.creative_commons_license).to eq('by-nc-sa')
     end
     it 'should not fail on an item with an empty datastream' do
       expect(@empty_item.creative_commons_license).to eq('')
@@ -159,7 +150,7 @@ describe Dor::Editable do
   end
   describe 'creative_commons_human' do
     it 'should find the human readable cc license' do
-      expect(@item.creative_commons_license_human).to eq('CC Attribution-NonCommercial-ShareAlike 3.0')
+      expect(@apo.creative_commons_license_human).to eq('CC Attribution-NonCommercial-ShareAlike 3.0')
     end
   end
   describe 'creative_commons_license=' do
@@ -180,8 +171,8 @@ describe Dor::Editable do
   end
   describe 'creative_commons_license_human=' do
     it 'should set the human readable cc license' do
-      @item.creative_commons_license_human = 'greetings'
-      expect(@item.creative_commons_license_human).to eq('greetings')
+      @apo.creative_commons_license_human = 'greetings'
+      expect(@apo.creative_commons_license_human).to eq('greetings')
     end
     it 'should work on an empty ds' do
       @empty_item.creative_commons_license_human = 'greetings'
@@ -220,20 +211,20 @@ describe Dor::Editable do
     end
     it 'should be able to remove the use license' do
       [:none, '  ', nil].each do |v|
-        @item.use_license = v
-        expect(@item.use_license).to eq('')
-        expect(@item.use_license_uri).to be_nil
-        expect(@item.use_license_human).to eq('')
-        expect(@item.creative_commons_license).to be_nil
-        expect(@item.creative_commons_license_human).to be_nil
-        expect(@item.open_data_commons_license).to be_nil
-        expect(@item.open_data_commons_license_human).to be_nil
+        @apo.use_license = v
+        expect(@apo.use_license).to eq('')
+        expect(@apo.use_license_uri).to be_nil
+        expect(@apo.use_license_human).to eq('')
+        expect(@apo.creative_commons_license).to be_nil
+        expect(@apo.creative_commons_license_human).to be_nil
+        expect(@apo.open_data_commons_license).to be_nil
+        expect(@apo.open_data_commons_license_human).to be_nil
       end
     end
   end
   describe 'default object rights' do
     it 'should find the default object rights' do
-      expect(@item.default_rights).to eq('World')
+      expect(@apo.default_rights).to eq('World')
     end
     it 'should use the OM template if the ds is empty' do
       expect(@empty_item.default_rights).to eq('World')
@@ -241,8 +232,8 @@ describe Dor::Editable do
   end
   describe 'default_rights=' do
     it 'should set default rights' do
-      @item.default_rights = 'stanford'
-      expect(@item.default_rights).to eq('Stanford')
+      @apo.default_rights = 'stanford'
+      expect(@apo.default_rights).to eq('Stanford')
     end
     it 'should work on an empty ds' do
       @empty_item.default_rights = 'stanford'
@@ -251,29 +242,29 @@ describe Dor::Editable do
   end
   describe 'desc metadata format' do
     it 'should find the desc metadata format' do
-      expect(@item.desc_metadata_format).to eq('MODS')
+      expect(@apo.desc_metadata_format).to eq('MODS')
     end
     it 'should not fail on an item with an empty datastream' do
       expect(@empty_item.desc_metadata_format).to eq(nil)
     end
     it 'should set dark correctly' do
-      @item.default_rights = 'dark'
-      expect(@item.default_rights).to eq('Dark')
+      @apo.default_rights = 'dark'
+      expect(@apo.default_rights).to eq('Dark')
     end
     it 'setters should be case insensitive' do
-      @item.default_rights = 'Dark'
-      expect(@item.default_rights).to eq('Dark')
+      @apo.default_rights = 'Dark'
+      expect(@apo.default_rights).to eq('Dark')
     end
     it 'should set read rights to none for dark' do
-      @item.default_rights = 'Dark'
-      xml = @item.datastreams['defaultObjectRights'].ng_xml
+      @apo.default_rights = 'Dark'
+      xml = @apo.datastreams['defaultObjectRights'].ng_xml
       expect(xml.search('//rightsMetadata/access[@type=\'read\']/machine/none').length).to eq(1)
     end
   end
   describe 'desc_metadata_format=' do
     it 'should set the desc metadata format' do
-      @item.desc_metadata_format = 'TEI'
-      expect(@item.desc_metadata_format).to eq('TEI')
+      @apo.desc_metadata_format = 'TEI'
+      expect(@apo.desc_metadata_format).to eq('TEI')
     end
     it 'should set the desc metadata format for an empty datastream' do
       @empty_item.desc_metadata_format = 'TEI'
@@ -282,7 +273,7 @@ describe Dor::Editable do
   end
   describe 'mods_title' do
     it 'should get the title' do
-      expect(@item.mods_title).to eq('Ampex')
+      expect(@apo.mods_title).to eq('Ampex')
     end
     it 'should not fail on an item with an empty datastream' do
       expect(@empty_item.mods_title).to eq('')
@@ -290,8 +281,8 @@ describe Dor::Editable do
   end
   describe 'mods_title=' do
     it 'should set the title' do
-      @item.mods_title = 'hello world'
-      expect(@item.mods_title).to eq('hello world')
+      @apo.mods_title = 'hello world'
+      expect(@apo.mods_title).to eq('hello world')
     end
     it 'should work on an empty datastream' do
       @empty_item.mods_title = 'hello world'
@@ -300,21 +291,21 @@ describe Dor::Editable do
   end
   describe 'default workflows' do
     it 'should find the default workflows' do
-      expect(@item.default_workflows).to eq(['digitizationWF'])
+      expect(@apo.default_workflows).to eq(['digitizationWF'])
     end
     it 'should be able to set default workflows' do
-      @item.default_workflow = 'accessionWF'
-      expect(@item.default_workflows).to eq(['accessionWF'])
+      @apo.default_workflow = 'accessionWF'
+      expect(@apo.default_workflows).to eq(['accessionWF'])
     end
     it 'should NOT be able to set a null default workflows' do
-      expect { @item.default_workflow = '' }.to raise_error(ArgumentError)
-      expect(@item.default_workflows).to eq(['digitizationWF']) # the original default workflow
+      expect { @apo.default_workflow = '' }.to raise_error(ArgumentError)
+      expect(@apo.default_workflows).to eq(['digitizationWF']) # the original default workflow
     end
   end
   describe 'copyright_statement=' do
     it 'should assign' do
-      @item.copyright_statement = 'hi'
-      expect(@item.copyright_statement).to eq('hi')
+      @apo.copyright_statement = 'hi'
+      expect(@apo.copyright_statement).to eq('hi')
     end
     it 'works on an empty datastream' do
       @empty_item.copyright_statement = 'hi'
@@ -323,36 +314,21 @@ describe Dor::Editable do
   end
   describe 'purge_roles' do
     it 'works' do
-      @item.purge_roles
-      expect(@item.roles).to eq({})
+      @apo.purge_roles
+      expect(@apo.roles).to eq({})
     end
   end
+
   describe 'agreement=' do
     it 'should assign' do
-      pending 'this test is probably checking AF internals'
-      agr = double
-      allow(agr).to receive(:pid).and_return('druid:dd327qr3670')
-      allow(@item).to receive(:agreement_object).and_return([agr])
-      rels_ext_ds = @item.datastreams['RELS-EXT']
-      expect(ActiveFedora::Base).to receive(:find_one).with('druid:new_agreement', true).and_return(mock_agreement)
-      @item.agreement = 'druid:new_agreement'
-      xml = Nokogiri::XML(rels_ext_ds.to_rels_ext.to_s)
-      expect(xml).to be_equivalent_to <<-XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:hydra="http://projecthydra.org/ns/relations#">
-        <rdf:Description rdf:about="info:fedora/druid:zt570tx3016">
-          <hydra:isGovernedBy rdf:resource="info:fedora/druid:hv992ry2431"/>
-          <hydra:referencesAgreement rdf:resource="info:fedora/druid:new_agreement"/>
-        </rdf:Description>
-      </rdf:RDF>
-      XML
+      skip 'dispatches "belongs_to" association for agreement_object down into internals of ActiveFedora'
     end
-
   end
+
   describe 'default_workflow=' do
     it 'should set the default workflow' do
-      @item.default_workflow = 'thisWF'
-      expect(@item.default_workflows).to include('thisWF')
+      @apo.default_workflow = 'thisWF'
+      expect(@apo.default_workflows).to include('thisWF')
     end
     it 'should work on an empty ds' do
       @empty_item.default_workflow = 'thisWF'
@@ -368,19 +344,20 @@ describe Dor::Editable do
       XML
     end
   end
+
   describe 'to_solr' do
     it 'should make a solr doc' do
-      allow(@item).to receive(:milestones).and_return({})
-      allow(@item).to receive(:agreement).and_return('druid:agreement')
-      allow(@item).to receive(:agreement_object).and_return(true)
-      solr_doc = @item.to_solr
+      allow(@apo).to receive(:milestones).and_return({})
+      allow(@apo).to receive(:agreement).and_return('druid:agreement')
+      allow(@apo).to receive(:agreement_object).and_return(true)
+      solr_doc = @apo.to_solr
       expect(solr_doc).to match a_hash_including('default_rights_ssim' => ['World'])
       expect(solr_doc).to match a_hash_including('agreement_ssim'      => ['druid:agreement'])
       # expect(solr_doc).to match a_hash_including("registration_default_collection_sim" => ["druid:fz306fj8334"])
       expect(solr_doc).to match a_hash_including('registration_workflow_id_ssim' => ['digitizationWF'])
       expect(solr_doc).to match a_hash_including('use_statement_ssim'  => ['Rights are owned by Stanford University Libraries. All Rights Reserved. This work is protected by copyright law. No part of the materials may be derived, copied, photocopied, reproduced, translated or reduced to any electronic medium or machine readable form, in whole or in part, without specific permission from the copyright holder. To access this content or to request reproduction permission, please send a written request to speccollref@stanford.edu.'])
       expect(solr_doc).to match a_hash_including('copyright_ssim'      => ['Additional copyright info'])
-      expect(solr_doc).to match a_hash_including('use_license_machine_ssi' => 'by-nc-sa')
+      expect(solr_doc).to match a_hash_including('default_use_license_machine_ssi' => 'by-nc-sa')
     end
   end
 end

--- a/spec/dor/rights_metadata_spec.rb
+++ b/spec/dor/rights_metadata_spec.rb
@@ -1,50 +1,48 @@
 require 'spec_helper'
 
-class RightsHaver < Dor::Item
-  # include Dor::Rightsable
-end
-
 describe Dor::RightsMetadataDS do
   before(:each) { stub_config }
   after(:each)  { unstub_config }
 
   before(:each) do
-    @item = instantiate_fixture('druid:bb046xn0881', RightsHaver)
-    # allow(@item).to receive(:new?).and_return(false)
+    @item = instantiate_fixture('druid:bb046xn0881', Dor::Item)
+    allow(Dor::Item).to receive(:find).with(@item.pid).and_return(@item)
     allow(@item).to receive(:workflows).and_return(double)
-    allow(Dor::Item).to receive(:find).with('druid:bb046xn0881').and_return(@item)
     allow(Dor::WorkflowService).to receive(:get_milestones).and_return([])
   end
 
   it '#new' do
-    expect(Dor::RightsMetadataDS.new).to be_a(Dor::RightsMetadataDS)
+    expect { Dor::RightsMetadataDS.new }.not_to raise_error
   end
 
   it 'should have a rightsMetadata datastream accessible' do
-    expect(@item).to be_a(RightsHaver)
-    expect(@item).to be_kind_of(Dor::Item)
     expect(@item.datastreams['rightsMetadata']).to be_a(Dor::RightsMetadataDS)
     expect(@item.rightsMetadata).to eq(@item.datastreams['rightsMetadata'])
   end
 
   describe 'rightsMetadata' do
     before :each do
-      @rm = @item.datastreams['rightsMetadata']
+      @rm = @item.rightsMetadata
     end
     it 'has accessors from defined terminology' do
-      expect(@rm.copyright  ).to eq ['Courtesy of the Revs Institute for Automotive Research. All rights reserved unless otherwise indicated.']
-      ## use.human differs from use_statement: the former hits two elements (one unpopulated), the latter only one
-      expect(@rm.use.human    ).to eq ['Users must contact the The Revs Institute for Automotive Research for re-use and reproduction information.', '']
+      expect(@rm.copyright).to eq ['Courtesy of the Revs Institute for Automotive Research. All rights reserved unless otherwise indicated.']
       expect(@rm.use_statement).to eq ['Users must contact the The Revs Institute for Automotive Research for re-use and reproduction information.']
-      expect(@rm.use.machine     ).to eq ['']
-      expect(@rm.creative_commons).to eq ['']
-      # The following tests fail if terminology defined with :type instead of :path => '/x/y[@type=...]'
-      expect(@rm.creative_commons_human).not_to include 'Users must contact the The Revs Institute for Automotive Research for re-use and reproduction information.'
-      expect(@rm.creative_commons_human).to eq ['']
+      expect(@rm.use_license).to eq ['by-nc']
+      ## use.human differs from use_statement: the former hits multiple elements, the latter only one
+      expect(@rm.use.human).to eq ['Users must contact the The Revs Institute for Automotive Research for re-use and reproduction information.', 'Attribution Non-Commercial 3.0 Unported']
     end
     it 'has a Dor::RightsAuth dra_object' do
       expect(@rm.dra_object).to be_a(Dor::RightsAuth)
       expect(@rm.dra_object.index_elements).to match a_hash_including(:primary => 'world_qualified', :errors => [])
+    end
+    it 'reads creative commons licenses correctly' do
+      expect(@rm.creative_commons).to eq ['by-nc']
+      # The following tests fail if terminology defined with :type instead of :path => '/x/y[@type=...]'
+      expect(@rm.creative_commons_human).not_to include 'Users must contact the The Revs Institute for Automotive Research for re-use and reproduction information.'
+      expect(@rm.creative_commons_human).to eq ['Attribution Non-Commercial 3.0 Unported']
+    end
+    it 'does not test open data commons licenses' do
+      skip
     end
   end
 
@@ -61,7 +59,8 @@ describe Dor::RightsMetadataDS do
         'title_tesim'         => ['Indianapolis 500'],
         'rights_characteristics_ssim' => include(
           'world_discover', 'has_group_rights', 'has_rule', 'group|stanford', 'world_read', 'world|no-download', 'profile:group1|world1'
-        )
+        ),
+        'use_license_machine_ssi'     => 'by-nc'
       )
       expect(doc).not_to include('rights_errors_ssim')  # don't include empties
     end

--- a/spec/fixtures/item_druid_bb046xn0881.xml
+++ b/spec/fixtures/item_druid_bb046xn0881.xml
@@ -470,10 +470,8 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
   </access>
   <use>
     <human type="useAndReproduction">Users must contact the The Revs Institute for Automotive Research for re-use and reproduction information.</human>
-  </use>
-  <use>
-    <human type="creativeCommons"></human>
-    <machine type="creativeCommons"></machine>
+    <human type="creativeCommons">Attribution Non-Commercial 3.0 Unported</human>
+    <machine type="creativeCommons">by-nc</machine>
   </use>
 </rightsMetadata>
 </foxml:xmlContent>
@@ -497,6 +495,8 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
   </access>
   <use>
     <human type="useAndReproduction">Users must contact The Revs Institute for Automotive Research for re-use and reproduction information.</human>
+    <human type="creativeCommons">Attribution Non-Commercial 3.0 Unported</human>
+    <machine type="creativeCommons">by-nc</machine>
   </use>
 </rightsMetadata>
 </foxml:xmlContent>


### PR DESCRIPTION
and default_use_license_machine from defaultObjectRights.

This PR extracts the `use_license_machine` data from `rightsMetadata` and creates a new field for APOs called `default_use_license_machine` which is extracted from `defaultObjectRights`.

This PR also deletes some XML templates not being used in `RightsMetadataDS` and does some clarity cleanup for the specs.