### PR TITLE
Stop truncating release_date in the model

### DIFF
--- a/lib/dor/datastreams/embargo_metadata_ds.rb
+++ b/lib/dor/datastreams/embargo_metadata_ds.rb
@@ -54,10 +54,10 @@ class EmbargoMetadataDS < ActiveFedora::OmDatastream
     term_values(:status).first
   end
 
-  # Sets the release date.  Converts the date to beginning-of-day, UTC to help with Solr indexing
-  # @param [Time] rd A Time object represeting the release date.  By default, it is set to now
+  # Sets the release date.  Does NOT convert to beginning-of-day.
+  # @param [Time] rd the release date object
   def release_date=(rd = Time.now.utc)
-    update_values([:release_date] => rd.beginning_of_day.utc.xmlschema)
+    update_values([:release_date] => rd.utc.xmlschema)
     self.content = ng_xml.to_s
   end
 

--- a/spec/datastreams/embargo_metadata_spec.rb
+++ b/spec/datastreams/embargo_metadata_spec.rb
@@ -81,9 +81,10 @@ describe Dor::EmbargoMetadataDS do
       @t = Time.now.utc - 10
       @ds.release_date = @t
     end
-    it '= sets releaseDate from a Time object as the start of day, UTC' do
+    it '= sets releaseDate from a Time object' do
+      # does NOT do beginning_of_day truncation, leave that for indexing
       rd = Time.parse(@ds.term_values(:release_date).first)
-      expect(rd).to eq(@t.beginning_of_day.utc)
+      expect(rd.strftime('%FT%T%z')).to eq(@t.strftime('%FT%T%z')) # not strictly equal since "now" has millesecond granularity
     end
     it '= marks the datastram as changed' do
       expect(@ds).to be_changed


### PR DESCRIPTION
Even if we wanted this, the model is the wrong place to do it.

And we don't want this.