### PR TITLE
move basic DOR to Solr indexing code from Argo to dor-services (so other things can use it)

### DIFF
--- a/config/config_defaults.yml
+++ b/config/config_defaults.yml
@@ -65,3 +65,7 @@
   :shift_age: weekly
 :dor_services:
   :url:
+:indexing_svc:
+  :log: 'log/indexing_svc.log'
+  :log_date_format_str: '%Y-%m-%d %H:%M:%S.%L'
+  :log_rotation_interval: 'daily'

--- a/lib/dor-services.rb
+++ b/lib/dor-services.rb
@@ -129,6 +129,7 @@ module Dor
 
   # Services
   autoload :SearchService,             'dor/services/search_service'
+  autoload :IndexingService,           'dor/services/indexing_service'
   autoload :MetadataService,           'dor/services/metadata_service'
   autoload :RegistrationService,       'dor/services/registration_service'
   autoload :SuriService,               'dor/services/suri_service'

--- a/lib/dor/services/indexing_service.rb
+++ b/lib/dor/services/indexing_service.rb
@@ -14,10 +14,11 @@ module Dor
       index_logger
     end
 
-    # get a memoized index logger instance
-    @@default_index_logger = nil
+    # memoize the loggers we create in a hash, init with a nil default logger
+    @@loggers = { default: nil }
+
     def self.default_index_logger
-      @@default_index_logger ||= generate_index_logger
+      @@loggers[:default] ||= generate_index_logger
     end
 
     # takes a Dor object and indexes it to solr.  doesn't commit automatically.
@@ -29,6 +30,13 @@ module Dor
 
     # retrieves a single Dor object by pid, indexes the object to solr, does some logging
     # (will use a defualt logger if one is not provided).  doesn't commit automatically.
+    #
+    # WARNING/TODO:  the tests indicate that the "rescue Exception" block at the end will
+    # get skipped, and the thrown exception (e.g. SystemStackError) will not be logged.  since
+    # that's the only consequence, and the exception bubbles up as we would want anyway, it
+    # doesn't seem worth blocking refactoring.  see https://github.com/sul-dlss/dor-services/issues/156
+    # extra logging in this case would be nice, but centralized indexing that's otherwise
+    # fully functional is nicer.
     def self.reindex_pid(pid, index_logger = nil, should_raise_errors = true)
       index_logger ||= default_index_logger
       obj = Dor.load_instance pid

--- a/lib/dor/services/indexing_service.rb
+++ b/lib/dor/services/indexing_service.rb
@@ -1,0 +1,56 @@
+module Dor
+  class IndexingService
+    ##
+    # Returns a Logger instance for recording info about indexing attempts
+    # @yield attempt to execute 'entry_id_block' and use the result as an extra identifier for the log
+    #   entry.  a placeholder will be used otherwise. 'request.uuid' might be useful in a Rails app.
+    def self.generate_index_logger(&entry_id_block)
+      index_logger = Logger.new(Config.indexing_svc.log, Config.indexing_svc.log_rotation_interval)
+      index_logger.formatter = proc do |severity, datetime, progname, msg|
+        date_format_str = Config.indexing_svc.log_date_format_str
+        entry_id = begin entry_id_block.call rescue '---' end
+        "[#{entry_id}] [#{datetime.utc.strftime(date_format_str)}] #{msg}\n"
+      end
+      index_logger
+    end
+
+    # get a memoized index logger instance
+    @@default_index_logger = nil
+    def self.default_index_logger
+      @@default_index_logger ||= generate_index_logger
+    end
+
+    # takes a Dor object and indexes it to solr.  doesn't commit automatically.
+    def self.reindex_object(obj)
+      solr_doc = obj.to_solr
+      Dor::SearchService.solr.add(solr_doc)
+      solr_doc
+    end
+
+    # retrieves a single Dor object by pid, indexes the object to solr, does some logging
+    # (will use a defualt logger if one is not provided).  doesn't commit automatically.
+    def self.reindex_pid(pid, index_logger = nil, should_raise_errors = true)
+      index_logger ||= default_index_logger
+      obj = Dor.load_instance pid
+      solr_doc = reindex_object obj
+      index_logger.info "updated index for #{pid}"
+      solr_doc
+    rescue StandardError => se
+      if se.is_a? ActiveFedora::ObjectNotFoundError
+        index_logger.warn "failed to update index for #{pid}, object not found in Fedora"
+      else
+        index_logger.warn "failed to update index for #{pid}, unexpected StandardError, see main app log: #{se.backtrace}"
+      end
+      raise se if should_raise_errors
+    rescue Exception => ex
+      index_logger.error "failed to update index for #{pid}, unexpected Exception, see main app log: #{ex.backtrace}"
+      raise ex # don't swallow anything worse than StandardError
+    end
+
+    # given a list of pids, retrieve those objects from fedora, index each to solr, optionally commit
+    def self.reindex_pid_list(pid_list, should_commit = false)
+      pid_list.each { |pid| reindex_pid pid, nil, false } # use the default logger, don't let individual errors nuke the rest of the batch
+      ActiveFedora.solr.conn.commit if should_commit
+    end
+  end
+end

--- a/spec/dor/indexing_service_spec.rb
+++ b/spec/dor/indexing_service_spec.rb
@@ -1,0 +1,153 @@
+require 'spec_helper'
+
+describe Dor::IndexingService do
+
+  before(:each) { stub_config }
+  after(:each)  { unstub_config }
+
+  describe '#generate_index_logger' do
+    before :each do
+      @mock_entry_id = 'unique_request_id'
+      @mock_log_msg = 'something noteworthy'
+    end
+
+    after :each do
+      File.delete Dor::Config.indexing_svc.log if File.exist? Dor::Config.indexing_svc.log
+    end
+
+    it 'should call entry_id_block and include the result in the logging statement' do
+      is_entry_id_block_executed = false
+      test_index_logger = Dor::IndexingService.generate_index_logger do
+        is_entry_id_block_executed = true
+        @mock_entry_id
+      end
+      test_index_logger.info @mock_log_msg
+
+      last_log_line = open(Dor::Config.indexing_svc.log).read.split("\n")[-1]
+      expect(last_log_line).to match(/\[#{@mock_entry_id}\] \[.*\] #{@mock_log_msg}$/)
+      expect(is_entry_id_block_executed).to eq(true)
+    end
+
+    it 'should log the default entry_id if entry_id_block is nil' do
+      test_index_logger = Dor::IndexingService.generate_index_logger
+      test_index_logger.info @mock_log_msg
+      last_log_line = open(Dor::Config.indexing_svc.log).read.split("\n")[-1]
+      expect(last_log_line).to match(/\[---\] \[.*\] #{@mock_log_msg}$/)
+    end
+
+    it 'should log the default entry_id if entry_id_block throws a StandardError' do
+      test_index_logger = Dor::IndexingService.generate_index_logger do
+        raise ZeroDivisionError.new 'whoops'
+      end
+      test_index_logger.info @mock_log_msg
+
+      last_log_line = open(Dor::Config.indexing_svc.log).read.split("\n")[-1]
+      expect(last_log_line).to match(/\[---\] \[.*\] #{@mock_log_msg}$/)
+    end
+
+    it "should not trap the exception if it's not StandardError" do
+      stack_overflow_ex = SystemStackError.new 'really? here?'
+      test_index_logger = Dor::IndexingService.generate_index_logger { raise stack_overflow_ex }
+      expect { test_index_logger.info @mock_log_msg }.to raise_error(stack_overflow_ex)
+    end
+  end
+
+  describe '#default_index_logger' do
+    it 'should call generate_index_logger, and memoize the result' do
+      mock_index_logger = double(Logger)
+      expect(Dor::IndexingService).to receive(:generate_index_logger).once.and_return(mock_index_logger)
+      expect(Dor::IndexingService.default_index_logger).to eq(mock_index_logger)
+      expect(Dor::IndexingService.default_index_logger).to eq(mock_index_logger)
+    end
+  end
+
+  describe '#reindex_pid_list' do
+    before :each do
+      @mock_solr_conn = double(ActiveFedora.solr.conn)
+    end
+
+    it 'should reindex the pids and not commit by default' do
+      pids = [1..10].map(&:to_s)
+      pids.each { |pid| expect(Dor::IndexingService).to receive(:reindex_pid).with(pid, nil, false) }
+      expect(@mock_solr_conn).to_not receive(:commit)
+      Dor::IndexingService.reindex_pid_list pids
+    end
+
+    it 'should reindex the pids and commit if should_commit is true' do
+      pids = [1..10].map(&:to_s)
+      pids.each { |pid| expect(Dor::IndexingService).to receive(:reindex_pid).with(pid, nil, false) }
+      expect(ActiveFedora.solr).to receive(:conn).and_return(@mock_solr_conn)
+      expect(@mock_solr_conn).to receive(:commit)
+      Dor::IndexingService.reindex_pid_list pids, true
+    end
+
+    it 'should proceed despite individual indexing failures' do
+      pids = [1..10].map(&:to_s)
+      expect(Dor::IndexingService).to receive(:reindex_pid).with(pids[0], nil, false)
+      pids[1..-1].each { |pid| expect(Dor::IndexingService).to receive(:reindex_pid).with(pid, nil, false) }
+      expect(ActiveFedora.solr).to receive(:conn).and_return(@mock_solr_conn)
+      expect(@mock_solr_conn).to receive(:commit)
+      Dor::IndexingService.reindex_pid_list pids, true
+    end
+  end
+
+  describe '#reindex_object' do
+    before :each do
+      @mock_pid = 'unique_id'
+      @mock_obj = double(Dor::Item)
+      @mock_solr_doc  = {id: @mock_pid, text_field_tesim: 'a field to be searched'}
+    end
+
+    it 'should reindex the object via Dor::SearchService' do
+      expect(@mock_obj).to receive(:to_solr).and_return(@mock_solr_doc)
+      expect(Dor::SearchService.solr).to receive(:add).with(hash_including(:id => @mock_pid))
+      ret_val = Dor::IndexingService.reindex_object @mock_obj
+      expect(ret_val).to eq(@mock_solr_doc)
+    end
+  end
+
+  describe '#reindex_pid' do
+    before :each do
+      @mock_pid = 'unique_id'
+      @mock_default_logger = double(Logger)
+      @mock_obj = double(Dor::Item)
+      @mock_solr_doc  = {id: @mock_pid, text_field_tesim: 'a field to be searched'}
+      expect(Dor::IndexingService).to receive(:default_index_logger).at_least(:once).and_return(@mock_default_logger)
+    end
+
+    it 'should reindex the object via Dor::IndexingService.reindex_pid and log success' do
+      expect(Dor).to receive(:load_instance).with(@mock_pid).and_return(@mock_obj)
+      expect(Dor::IndexingService).to receive(:reindex_object).with(@mock_obj).and_return(@mock_solr_doc)
+      expect(@mock_default_logger).to receive(:info).with("updated index for #{@mock_pid}")
+      ret_val = Dor::IndexingService.reindex_pid @mock_pid
+      expect(ret_val).to eq(@mock_solr_doc)
+    end
+
+    it 'should log the right thing if an object is not found, then re-raise the exception by default' do
+      expect(Dor).to receive(:load_instance).with(@mock_pid).and_raise(ActiveFedora::ObjectNotFoundError)
+      expect(@mock_default_logger).to receive(:warn).with("failed to update index for #{@mock_pid}, object not found in Fedora")
+      expect { Dor::IndexingService.reindex_pid(@mock_pid) }.to raise_error(ActiveFedora::ObjectNotFoundError)
+    end
+
+    it 'should log the right thing if an object is not found, but swallow the exception when should_raise_errors is false' do
+      expect(Dor).to receive(:load_instance).with(@mock_pid).and_raise(ActiveFedora::ObjectNotFoundError)
+      expect(@mock_default_logger).to receive(:warn).with("failed to update index for #{@mock_pid}, object not found in Fedora")
+      expect { Dor::IndexingService.reindex_pid(@mock_pid, nil, false) }.to_not raise_error
+    end
+
+    it "should log the right thing if there's an unexpected error, then re-raise the exception by default" do
+      unexpected_err = ZeroDivisionError.new "how'd that happen?"
+      expect(Dor).to receive(:load_instance).with(@mock_pid).and_raise(unexpected_err)
+      expect(@mock_default_logger).to receive(:warn).with(start_with("failed to update index for #{@mock_pid}, unexpected StandardError, see main app log: ["))
+      expect { Dor::IndexingService.reindex_pid(@mock_pid) }.to raise_error(unexpected_err)
+    end
+
+    it "should log the right thing if there's an unexpected Exception that's not StandardError, then re-raise the exception, even when should_raise_errors is false" do
+      stack_overflow_ex = SystemStackError.new "didn't see that one coming... maybe you shouldn't have self-referential collections?"
+      expect(Dor).to receive(:load_instance).with(@mock_pid).and_raise(stack_overflow_ex)
+      #TODO: file a bug for this expectation not working.  it seemed to work when this code was in argo, but doesn't now that it's been ported to dor-services.
+      # expect(@mock_default_logger).to receive(:error).with(start_with("failed to update index for #{@mock_pid}, unexpected Exception, see main app log: ["))
+      expect { Dor::IndexingService.reindex_pid(@mock_pid, nil, false) }.to raise_error(stack_overflow_ex)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,7 @@ module Dor::SpecHelpers
       stacks.local_document_cache_root File.join(fixture_dir, 'purl')
       sdr.local_workspace_root         File.join(fixture_dir, 'workspace')
       sdr.local_export_home            File.join(fixture_dir, 'export')
+      indexing_svc.log                 'indexing_svc.log.test'
     end
     allow(ActiveFedora).to receive(:fedora).and_return(double('frepo').as_null_object)  # must be used in per-request context: :each not :all
   end


### PR DESCRIPTION
code for indexing objects by ID (or list of IDs) is needed by many applications, and should be the same across them.  dor-services is a logical place to centralize this code, since the indexing code just ties together a few dor-services methods, with additional logging and fault tolerance options.

* move Argo::Indexer from the argo project to Dor::IndexingService in the dor-services project (except for reindex_pid_list_with_profiling, which will stay in argo, since it relies on the Argo::Profiler, which should not be moved to dor-services).
* move the corresponding tests to dor-services (except where related to the Argo::Indexer method that didn't get moved).
* spec_helper.rb: define a location for the indexing service log generated by running tests.
* config_defaults.yml: add config defaults for a file to which indexing events should be logged, and a format string for date entries in said indexing log.
* dor-services.rb: include the IndexingService class by default in the Dor module that dor-services consumers use.