### PR TITLE
5.x: add externalFile support to public_xml generation of contentMetadata

### DIFF
--- a/lib/dor/datastreams/content_metadata_ds.rb
+++ b/lib/dor/datastreams/content_metadata_ds.rb
@@ -37,10 +37,39 @@ module Dor
     # @return [Nokogiri::XML::Document] sanitized for public consumption
     def public_xml
       result = ng_xml.clone
-      result.xpath('/contentMetadata/resource[not(file[(@deliver="yes" or @publish="yes")])]'   ).each(&:remove)
-      result.xpath('/contentMetadata/resource/file[not(@deliver="yes" or @publish="yes")]'      ).each(&:remove)
-      result.xpath('/contentMetadata/resource/file').xpath('@preserve|@shelve|@publish|@deliver').each(&:remove)
-      result.xpath('/contentMetadata/resource/file/checksum'                                    ).each(&:remove)
+
+      # remove any resources or attributes that are not destined for the public XML
+      result.xpath('/contentMetadata/resource[not(file[(@deliver="yes" or @publish="yes")]|externalFile)]').each(&:remove)
+      result.xpath('/contentMetadata/resource/file[not(@deliver="yes" or @publish="yes")]'                ).each(&:remove)
+      result.xpath('/contentMetadata/resource/file').xpath('@preserve|@shelve|@publish|@deliver'          ).each(&:remove)
+      result.xpath('/contentMetadata/resource/file/checksum'                                              ).each(&:remove)
+
+      # support for dereferencing links via externalFile element(s) to the source (child) item - see JUMBO-19
+      result.xpath('/contentMetadata/resource/externalFile').each do |externalFile|
+        # enforce pre-conditions that resourceId, objectId, fileId are required
+        src_resource_id = externalFile['resourceId']
+        src_druid = externalFile['objectId']
+        src_file_id = externalFile['fileId']
+        fail ArgumentError, "Malformed externalFile data: #{externalFile.inspect}" if [src_resource_id, src_file_id, src_druid].map(&:blank?).any?
+
+        # grab source item
+        src_item = Dor::Item.find(src_druid)
+
+        # locate and extract the resourceId/fileId elements
+        doc = src_item.datastreams['contentMetadata'].ng_xml
+        src_resource = doc.at_xpath("//resource[@id=\"#{src_resource_id}\"]")
+        src_file = src_resource.at_xpath("file[@id=\"#{src_file_id}\"]")
+        src_image_data = src_file.at_xpath('imageData')
+
+        # always use title regardless of whether a child label is present
+        src_label = doc.create_element('label')
+        src_label.content = src_item.datastreams['DC'].title.first
+
+        # add the extracted label and imageData
+        externalFile.add_previous_sibling(src_label)
+        externalFile << src_image_data unless src_image_data.nil?
+      end
+      
       result
     end
 

--- a/lib/dor/models/publishable.rb
+++ b/lib/dor/models/publishable.rb
@@ -41,7 +41,6 @@ module Dor
       rels = public_relationships.root
       pub.add_child(rels.clone) unless rels.nil? # TODO: Should never be nil in practice; working around an ActiveFedora quirk for testing
       pub.add_child(generate_dublin_core.root.clone)
-      @public_xml_doc = pub # save this for possible IIIF Presentation manifest
       pub.add_child(Nokogiri(generate_release_xml).root.clone) unless release_xml.children.size == 0 # If there are no release_tags, this prevents an empty <releaseData/> from being added
       # Note we cannot base this on if an individual object has release tags or not, because the collection may cause one to be generated for an item,
       # so we need to calculate it and then look at the final result.s

--- a/spec/dor/publishable_spec.rb
+++ b/spec/dor/publishable_spec.rb
@@ -12,6 +12,10 @@ class DescribableItem < ActiveFedora::Base
   include Dor::Processable
 end
 
+class ItemizableItem < ActiveFedora::Base
+  include Dor::Itemizable
+end
+
 describe Dor::Publishable do
 
   before(:each) { stub_config   }
@@ -225,6 +229,89 @@ describe Dor::Publishable do
           File.open(File.join(druid1.path, 'tmpfile'), 'w') {|f| f.write 'junk' }
           @item.publish_metadata
           expect(File).to_not exist(druid1.path)
+        end
+      end
+      
+      it 'handles externalFile references' do
+        correctPublicContentMetadata = Nokogiri::XML(read_fixture('hj097bm8879_publicObject.xml')).at_xpath('/publicObject/contentMetadata').to_xml               
+        @item.contentMetadata.content = read_fixture('hj097bm8879_contentMetadata.xml')
+        
+        # setup stubs for child items
+        %w(cg767mn6478 jw923xn5254).each do |druid|
+          child_item = ItemizableItem.new(:pid => "druid:#{druid}")
+
+          # load child content metadata fixture
+          dsid = 'contentMetadata'
+          child_item.datastreams[dsid] = Dor::ContentMetadataDS.from_xml read_fixture("#{druid}_#{dsid}.xml")
+
+          # load child DC metadata fixture and set label
+          dsid = 'DC'
+          child_item.datastreams[dsid] = Dor::SimpleDublinCoreDs.from_xml read_fixture("#{druid}_#{dsid}.xml")
+          child_item.label = child_item.datastreams[dsid].title
+
+          # stub out retrieval for child item
+          allow(Dor::Item).to receive(:find).with(child_item.pid).and_return(child_item)
+        end
+        
+        # generate publicObject XML and verify that the content metadata portion is correct
+        expect(Nokogiri::XML(@item.public_xml).at_xpath('/publicObject/contentMetadata').to_xml).to be_equivalent_to(correctPublicContentMetadata)
+      end
+
+      context 'handles errors for externalFile references' do
+        it 'is missing resourceId and mimetype attributes' do
+          @item.contentMetadata.content = <<-EOXML
+          <contentMetadata objectId="hj097bm8879" type="map">
+            <resource id="hj097bm8879_1" sequence="1" type="image">
+              <externalFile fileId="2542A.jp2" objectId="druid:cg767mn6478"/>
+              <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
+            </resource>
+          </contentMetadata>        
+          EOXML
+
+          # generate publicObject XML and verify that the content metadata portion is invalid
+          expect { Nokogiri::XML(@item.public_xml) }.to raise_error(ArgumentError)
+        end
+
+        it 'has blank resourceId attribute' do
+          @item.contentMetadata.content = <<-EOXML
+          <contentMetadata objectId="hj097bm8879" type="map">
+            <resource id="hj097bm8879_1" sequence="1" type="image">
+              <externalFile fileId="2542A.jp2" objectId="druid:cg767mn6478" resourceId=" " mimetype="image/jp2"/>
+              <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
+            </resource>
+          </contentMetadata>        
+          EOXML
+
+          # generate publicObject XML and verify that the content metadata portion is invalid
+          expect { Nokogiri::XML(@item.public_xml) }.to raise_error(ArgumentError)
+        end
+
+        it 'has blank fileId attribute' do
+          @item.contentMetadata.content = <<-EOXML
+          <contentMetadata objectId="hj097bm8879" type="map">
+            <resource id="hj097bm8879_1" sequence="1" type="image">
+              <externalFile fileId=" " objectId="druid:cg767mn6478" resourceId="cg767mn6478_1" mimetype="image/jp2"/>
+              <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
+            </resource>
+          </contentMetadata>        
+          EOXML
+
+          # generate publicObject XML and verify that the content metadata portion is invalid
+          expect { Nokogiri::XML(@item.public_xml) }.to raise_error(ArgumentError)
+        end
+
+        it 'has blank objectId attribute' do
+          @item.contentMetadata.content = <<-EOXML
+          <contentMetadata objectId="hj097bm8879" type="map">
+            <resource id="hj097bm8879_1" sequence="1" type="image">
+              <externalFile fileId="2542A.jp2" objectId=" " resourceId="cg767mn6478_1" mimetype="image/jp2"/>
+              <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
+            </resource>
+          </contentMetadata>        
+          EOXML
+
+          # generate publicObject XML and verify that the content metadata portion is invalid
+          expect { Nokogiri::XML(@item.public_xml) }.to raise_error(ArgumentError)
         end
       end
 

--- a/spec/fixtures/cg767mn6478_DC.xml
+++ b/spec/fixtures/cg767mn6478_DC.xml
@@ -1,0 +1,4 @@
+<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <dc:title>Cover: Carey's American atlas.</dc:title>
+  <dc:identifier>druid:cg767mn6478</dc:identifier>
+</oai_dc:dc>

--- a/spec/fixtures/cg767mn6478_contentMetadata.xml
+++ b/spec/fixtures/cg767mn6478_contentMetadata.xml
@@ -1,0 +1,15 @@
+<contentMetadata objectId="cg767mn6478" type="image">
+  <resource id="cg767mn6478_1" sequence="1" type="image">
+    <label>Image 1</label>
+    <file id="2542A.tif" preserve="yes" publish="no" shelve="no" mimetype="image/tiff" size="92217124">
+      <checksum type="md5">5b79c8570b7ef582735f912aa24ce5f2</checksum>
+      <checksum type="sha1">1f09f8796bfa67db97557f3de48a96c87b286d32</checksum>
+      <imageData width="6475" height="4747"/>
+    </file>
+    <file id="2542A.jp2" mimetype="image/jp2" size="5789764" preserve="no" publish="yes" shelve="yes">
+      <checksum type="md5">cd5ca5c4666cfd5ce0e9dc8c83461d7a</checksum>
+      <checksum type="sha1">39feed6ee1b734cab2d6a446e909a9fc7ac6fd01</checksum>
+      <imageData width="6475" height="4747"/>
+    </file>
+  </resource>
+</contentMetadata>

--- a/spec/fixtures/hj097bm8879_contentMetadata.xml
+++ b/spec/fixtures/hj097bm8879_contentMetadata.xml
@@ -1,0 +1,10 @@
+<contentMetadata objectId="hj097bm8879" type="map">
+  <resource id="hj097bm8879_1" sequence="1" type="image">
+    <externalFile fileId="2542A.jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1" mimetype="image/jp2"/>
+    <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_2" sequence="2" thumb="yes" type="image">
+    <externalFile fileId="2542B.jp2" objectId="druid:jw923xn5254" resourceId="jw923xn5254_1" mimetype="image/jp2"/>
+    <relationship objectId="druid:jw923xn5254" type="alsoAvailableAs"/>
+  </resource>
+</contentMetadata>        

--- a/spec/fixtures/hj097bm8879_publicObject.xml
+++ b/spec/fixtures/hj097bm8879_publicObject.xml
@@ -1,0 +1,110 @@
+<publicObject id="druid:hj097bm8879" published="2015-09-09T13:33:17-07:00">
+<identityMetadata>
+<sourceId source="Rumsey">2542</sourceId>
+<objectId>druid:hj097bm8879</objectId>
+<objectCreator>DOR</objectCreator>
+<objectLabel>Rumsey Atlas 2542</objectLabel>
+<objectType>item</objectType>
+<otherId name="catkey">10449093</otherId>
+<otherId name="uuid">3526ef90-1f4b-11e5-b0dc-0050569b3c3c</otherId>
+<tag>Project : Rumsey : AtlasProto</tag>
+<tag>Remediated By : 4.21.0</tag>
+<release to="Searchworks">true</release>
+</identityMetadata>
+<contentMetadata objectId="hj097bm8879" type="map">
+  <resource id="hj097bm8879_1" sequence="1" type="image">
+    <label>Cover: Carey's American atlas.</label>
+    <externalFile fileId="2542A.jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1" mimetype="image/jp2">
+      <imageData width="6475" height="4747"/>
+    </externalFile>
+    <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_2" sequence="2" thumb="yes" type="image">
+    <label>Title Page: Carey's American atlas.</label>
+    <externalFile fileId="2542B.jp2" objectId="druid:jw923xn5254" resourceId="jw923xn5254_1" mimetype="image/jp2">
+      <imageData width="3139" height="4675"/>
+    </externalFile>
+    <relationship objectId="druid:jw923xn5254" type="alsoAvailableAs"/>
+  </resource>
+</contentMetadata>
+<rightsMetadata>
+<copyright>
+<human type="copyright">
+Property rights reside with the repository, Copyright © Stanford University. Images may be reproduced or transmitted, but not for commercial use. For commercial use or commercial republication, contact rumseymapcenter@stanford.edu This work is licensed under a Creative Commons License. By downloading any images from this site, you agree to the terms of that license.
+</human>
+</copyright>
+<access type="discover">
+<machine>
+<world/>
+</machine>
+</access>
+<access type="read">
+<machine>
+<world/>
+</machine>
+</access>
+<use>
+<human type="useAndReproduction">
+To obtain permission to publish or reproduce commercially, please contact the Digital &amp; Rare Map Librarian, David Rumsey Map Center at rumseymapcenter@stanford.edu.
+</human>
+</use>
+<use>
+<machine type="creativeCommons">by-nc-sa</machine>
+<human type="creativeCommons">
+Attribution Non-Commercial Share Alike 3.0 Unported
+</human>
+</use>
+</rightsMetadata>
+<rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description rdf:about="info:fedora/druid:hj097bm8879">
+<fedora:isMemberOf rdf:resource="info:fedora/druid:xh235dd9059"/>
+<fedora:isMemberOfCollection rdf:resource="info:fedora/druid:xh235dd9059"/>
+</rdf:Description>
+</rdf:RDF>
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+<dc:title>
+Carey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]
+</dc:title>
+<dc:contributor>Carey, Mathew.</dc:contributor>
+<dc:contributor>Barker, W.</dc:contributor>
+<dc:contributor>Doolittle, Amos.</dc:contributor>
+<dc:contributor>Harris, Caleb &amp; Harding.</dc:contributor>
+<dc:contributor>Harrison, Junr.</dc:contributor>
+<dc:contributor>Lewis, Samuel.</dc:contributor>
+<dc:contributor>Scott, J.T.</dc:contributor>
+<dc:contributor>Smith, Genl. D.</dc:contributor>
+<dc:contributor>Smither, T.</dc:contributor>
+<dc:contributor>Vallance.</dc:contributor>
+<dc:type>map</dc:type>
+<dc:type>cartographic image</dc:type>
+<dc:type>Atlases.</dc:type>
+<dc:date>1795</dc:date>
+<dc:date>1795.</dc:date>
+<dc:publisher>Mathew Carey,</dc:publisher>
+<dc:language>eng</dc:language>
+<dc:format>1 atlas : 21 maps ; 37 x 24 cm</dc:format>
+<dc:format>cartographic material</dc:format>
+<dc:description>
+First atlas of America printed in America. First edition. These maps were also published in Carey's American edition of Guthrie's Geography (1795) and most of the maps say "engraved for Carey's American edition of Guthrie's Geography improved." The maps were again used for the 1796 edition of Carey's General Atlas, unchanged except for the Tennessee map, which is titled "Tennassee State" instead of "Tennassee Government" which is the title in both the American Atlas and the Guthrie Atlas -see Wheat and Brun, and has several counties delineated in the eastern part of the state which do not show in the 1795 edition of the map. NMM 480 (American Atlas) has "Tennassee State" indicating that Carey was not consistent. This atlas was the model for John Reid's American Atlas of 1796. This copy's maps have very strong impressions. Rebound quarter leather, marbled paper covered boards.
+</dc:description>
+<dc:description>National Atlas.</dc:description>
+<dc:description>References: P1172; Walsh p33; NMM 480; Howes C135.</dc:description>
+<dc:description type="local" displayLabel="Local note">Pub list no.: 2542.000.</dc:description>
+<dc:subject>Maps</dc:subject>
+<dc:coverage>Western Hemisphere</dc:coverage>
+<dc:coverage>North America</dc:coverage>
+<dc:coverage>South America</dc:coverage>
+<dc:coverage>United States</dc:coverage>
+<dc:coverage>Canada</dc:coverage>
+<dc:subject>G1100 1795 .C3 F</dc:subject>
+<dc:identifier>
+http://www.davidrumsey.com/luna/servlet/view/search?QuickSearchA=QuickSearchA&amp;q=2542.000&amp;sort=pub_list_no_initialsort%2Cpub_date%2Cpub_list_no%2Cseries_no&amp;search=Search
+</dc:identifier>
+<dc:relation type="collection">
+David Rumsey Map Collection at Stanford University Libraries
+</dc:relation>
+</oai_dc:dc>
+<releaseData>
+<release to="Searchworks">true</release>
+</releaseData>
+</publicObject>

--- a/spec/fixtures/jw923xn5254_DC.xml
+++ b/spec/fixtures/jw923xn5254_DC.xml
@@ -1,0 +1,4 @@
+<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <dc:title>Title Page: Carey's American atlas.</dc:title>
+  <dc:identifier>druid:jw923xn5254</dc:identifier>
+</oai_dc:dc>

--- a/spec/fixtures/jw923xn5254_contentMetadata.xml
+++ b/spec/fixtures/jw923xn5254_contentMetadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<contentMetadata objectId="jw923xn5254" type="image">
+  <resource id="jw923xn5254_1" sequence="1" type="image">
+    <label>Image 1</label>
+    <file id="2542B.tif" preserve="yes" publish="no" shelve="no" mimetype="image/tiff" size="44028890">
+      <checksum type="md5">b5f6fcd6eb0ad02800aeb82cba6d0eed</checksum>
+      <checksum type="sha1">a90aea983620238d8e1384d9a5cb683c6acd6984</checksum>
+      <imageData width="3139" height="4675"/>
+    </file>
+    <file id="2542B.jp2" mimetype="image/jp2" size="2762668" preserve="no" publish="yes" shelve="yes">
+      <checksum type="md5">bccdbb2500bb139d6d622321bfd2aa57</checksum>
+      <checksum type="sha1">80454c111675ec7e2c425e909810c49a69ffef26</checksum>
+      <imageData width="3139" height="4675"/>
+    </file>
+  </resource>
+</contentMetadata>


### PR DESCRIPTION
This PR forward ports https://github.com/sul-dlss/dor-services/pull/128 to the `develop` (5.x) branch.