### PR TITLE
upgrade stanford-mods dependency, update calling code and related tests

### DIFF
--- a/dor-services.gemspec
+++ b/dor-services.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'lyber-utils', '~> 0.1.2'
   s.add_dependency 'moab-versioning', '~> 1.4.4' # 1.3.2 fails, 1.4.3 fails
   s.add_dependency 'modsulator', '~> 0.0.7'
-  s.add_dependency 'stanford-mods', '= 1.3.3' # 1.3.4 fails on pub_date_sort, 1.4.0 fails
+  s.add_dependency 'stanford-mods', '= 1.5.3'  # v1.5.4 changes what sw_genre returns, which breaks test expectations.  TODO: figure out how to keep argo indexed counterparts of searchworks fields in sync w/ current SW behavior.
 
   # Bundler will install these gems too if you've checked out dor-services source from git and run 'bundle install'
   # It will not add these as dependencies if you require dor-services for other projects

--- a/lib/dor/models/describable.rb
+++ b/lib/dor/models/describable.rb
@@ -12,7 +12,7 @@ module Dor
       has_metadata :name => 'descMetadata', :type => Dor::DescMetadataDS, :label => 'Descriptive Metadata', :control_group => 'M'
     end
 
-    require 'stanford-mods/searchworks'
+    require 'stanford-mods'
 
     # intended for read-access, "as SearchWorks would see it", mostly for to_solr()
     # @param [Nokogiri::XML::Document] content Nokogiri descMetadata document (overriding internal data)
@@ -241,8 +241,9 @@ module Dor
           solr_doc[solr_key].push *vals unless vals.nil? || vals.empty?
           # asterisk to avoid multi-dimensional array: push values, not the array
         end
-        solr_doc['sw_pub_date_sort_ssi' ] = mods.pub_date_sort  # e.g. '0800'
-        solr_doc['sw_pub_date_facet_ssi'] = mods.pub_date_facet # e.g. '9th century'
+        solr_doc['sw_pub_date_sort_ssi' ] = mods.pub_year_sort_str  # e.g. '0800'
+        solr_doc['sw_pub_date_sort_isi' ] = mods.pub_year_int  # e.g. '0800'
+        solr_doc['sw_pub_date_facet_ssi'] = mods.pub_year_display_str # e.g. '9th century'
       end
       # some fields get explicit "(none)" placeholder values, mostly for faceting
       %w(sw_language_tesim sw_genre_tesim sw_format_tesim).each { |key| solr_doc[key] = ['(none)'] if solr_doc[key].empty? }

--- a/spec/dor/describable_spec.rb
+++ b/spec/dor/describable_spec.rb
@@ -573,7 +573,7 @@ describe Dor::Describable do
       expect{sm = @obj.stanford_mods}.not_to raise_error
       expect(sm).to be_kind_of(Stanford::Mods::Record)
       expect(sm.format_main).to eq(['Book'])
-      expect(sm.pub_date_sort).to eq('1911')
+      expect(sm.pub_year_sort_str).to eq('1911')
     end
     it 'should allow override argument(s)' do
       sm = nil
@@ -581,7 +581,7 @@ describe Dor::Describable do
       expect{sm = @obj.stanford_mods(nk, false)}.not_to raise_error
       expect(sm).to be_kind_of(Stanford::Mods::Record)
       expect(sm.genre.text).to eq('ape')
-      expect(sm.pub_date_sort).to be_nil
+      expect(sm.pub_year_sort_str).to be_nil
     end
   end
 
@@ -601,6 +601,7 @@ describe Dor::Describable do
         'sw_subject_temporal_ssim'    => ['1800-1900'],
         'sw_subject_temporal_tesim'   => ['1800-1900'],
         'sw_pub_date_sort_ssi'        => '1911',
+        'sw_pub_date_sort_isi'        => 1911,
         'sw_pub_date_facet_ssi'       => '1911'
       )
     end
@@ -625,6 +626,7 @@ describe Dor::Describable do
         'sw_subject_temporal_ssim'  => a_collection_containing_exactly('18th century', '17th century'),
         'sw_subject_temporal_tesim' => a_collection_containing_exactly('18th century', '17th century'),
         'sw_pub_date_sort_ssi'      => '1600',
+        'sw_pub_date_sort_isi'      => 1600,
         'sw_pub_date_facet_ssi'     => '1600'
       )
     end


### PR DESCRIPTION
* pin to stanford-mods 1.5.3, use 1.3.3
* pub_date_sort and pub_date_facet deprecated in favor of (respectively) pub_year_sort_str and pub_year_display_str.  update calls accordingly.
* index the newly available pub_year_int (an int equivalent of pub_year_sort_str) as sw_pub_date_sort_isi.
* update mocked pub_date_sort calls to pub_year_sort_str.
* add test info for new sw_pub_date_sort_isi field.
* require 'stanford-mods' instead of 'stanford-mods/searchworks', since the desired methods were moved to 'stanford-mods/origin_info' (but including just origin_info failed to load the method, and there seems to be no harm in loading the whole stanford-mods gem).