### PR TITLE
4.x: use content= to ensure proper persistence behavior

### DIFF
--- a/lib/dor/datastreams/content_metadata_ds.rb
+++ b/lib/dor/datastreams/content_metadata_ds.rb
@@ -157,7 +157,7 @@ module Dor
       resource << generate_also_available_as_node(child_druid)
       
       # save the virtual resource as a sibling and return
-      self.ng_xml.root << resource
+      self.content = (self.ng_xml.root << resource).to_xml
       resource
     end
 

--- a/spec/dor/content_metadata_ds_spec.rb
+++ b/spec/dor/content_metadata_ds_spec.rb
@@ -255,6 +255,7 @@ describe Dor::ContentMetadataDS do
       </resource>
       ').root
     
+      expect(@item.contentMetadata).to receive(:'content=').and_call_original
       @item.contentMetadata.add_virtual_resource(child_druid, child_resource)
       nodes = @item.contentMetadata.ng_xml.search('//resource[@id=\'ab123cd4567_2\']')
       expect(nodes.length).to eq(1)
@@ -295,7 +296,8 @@ describe Dor::ContentMetadataDS do
         </file>
       </resource>
       ').root
-  
+
+      expect(@item.contentMetadata).to receive(:'content=').and_call_original
       @item.contentMetadata.add_virtual_resource(child_druid, child_resource)
       nodes = @item.contentMetadata.ng_xml.search('//resource[@id=\'ab123cd4567_2\']')
       externalFile = nodes.search('externalFile')


### PR DESCRIPTION
This PR fixes a bug with persistence of the `add_virtual_resource` method. Modifying the `ng_xml` document doesn't trigger the dirty behavior correctly, so we use `content=` to modify the document.

This shouldn't need to be cherry-picked as 5.x looks to have this bug fix: https://github.com/sul-dlss/dor-services/blob/develop/lib/dor/datastreams/content_metadata_ds.rb#L201-L204