### PR TITLE
Use and store the instantiatable Dor::WorkflowService within the Dor::Config

### DIFF
--- a/lib/dor/config.rb
+++ b/lib/dor/config.rb
@@ -25,15 +25,6 @@ module Dor
       ensure
         $-v = temp_v
       end
-      params = { :dor_services_url => result.dor_services.url }
-
-      if result.workflow.logfile && result.workflow.shift_age
-        params[:logger] = Logger.new(result.workflow.logfile, result.workflow.shift_age)
-      elsif result.workflow.logfile
-        params[:logger] = Logger.new(result.workflow.logfile)
-      end
-      params[:timeout] = result.workflow.timeout if result.workflow.timeout
-      Dor::WorkflowService.configure result.workflow.url, params
       result
     end
 
@@ -84,6 +75,19 @@ module Dor
         :stomp => {
           :connection => Confstruct.deferred { |c| Stomp::Connection.new c.user, c.password, c.host, c.port, true, 5, { 'client-id' => c.client_id }},
           :client => Confstruct.deferred { |c| Stomp::Client.new c.user, c.password, c.host, c.port }
+        },
+        :workflow => {
+          :client => Confstruct.deferred do |c|
+            Dor::WorkflowService.configure c.url, logger: c.client_logger, timeout: c.timeout, dor_services_url: config.dor_services.url
+            Dor::WorkflowService
+          end,
+          :client_logger => Confstruct.deferred do |c|
+            if c.logfile && c.shift_age
+              Logger.new(c.logfile, c.shift_age)
+            elsif c.logfile
+              Logger.new(c.logfile)
+            end
+          end
         }
       })
       true

--- a/lib/dor/datastreams/workflow_definition_ds.rb
+++ b/lib/dor/datastreams/workflow_definition_ds.rb
@@ -70,7 +70,7 @@ class WorkflowDefinitionDs < ActiveFedora::OmDatastream
     end
   end
 
-  # Creates the xml used by Dor::WorkflowService.create_workflow
+  # Creates the xml used by Dor::WorkflowService#create_workflow
   # @return [String] An object's initial workflow as defined by the <workflow-def> in content
   def initial_workflow
     doc = Nokogiri::XML('<workflow/>')

--- a/lib/dor/datastreams/workflow_ds.rb
+++ b/lib/dor/datastreams/workflow_ds.rb
@@ -17,7 +17,7 @@ module Dor
     end
 
     def get_workflow(wf, repo = 'dor')
-      xml = Dor::WorkflowService.get_workflow_xml(repo, pid, wf)
+      xml = Dor::Config.workflow.client.get_workflow_xml(repo, pid, wf)
       xml = Nokogiri::XML(xml)
       return nil if xml.xpath('workflow').length == 0
       Workflow::Document.new(xml.to_s)
@@ -34,12 +34,12 @@ module Dor
     # service directly
     def content(refresh = false)
       @content = nil if refresh
-      @content ||= Dor::WorkflowService.get_workflow_xml 'dor', pid, nil
-    rescue Dor::WorkflowException => e
+      @content ||= Dor::Config.workflow.client.get_workflow_xml 'dor', pid, nil
+    rescue Dor::WorkflowException
       xml = Nokogiri::XML(%(<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<workflows objectId="#{pid}"/>))
       digital_object.datastreams.keys.each do |dsid|
         next unless dsid =~ /WF$/
-        ds_content = Nokogiri::XML(Dor::WorkflowService.get_workflow_xml 'dor', pid, dsid)
+        ds_content = Nokogiri::XML(Dor::Config.workflow.client.get_workflow_xml('dor', pid, dsid))
         xml.root.add_child(ds_content.root)
       end
       @content ||= xml.to_xml

--- a/lib/dor/models/processable.rb
+++ b/lib/dor/models/processable.rb
@@ -100,7 +100,7 @@ module Dor
     end
 
     def milestones
-      Dor::WorkflowService.get_milestones('dor', pid)
+      Dor::Config.workflow.client.get_milestones('dor', pid)
     end
 
     # @return [Hash{Symbol => Object}] including :current_version, :status_code and :status_time
@@ -214,7 +214,7 @@ module Dor
       priority = workflows.current_priority if priority == 0
       opts = { :create_ds => create_ds, :lane_id => default_workflow_lane }
       opts[:priority] = priority if priority > 0
-      Dor::WorkflowService.create_workflow(Dor::WorkflowObject.initial_repo(name), pid, name, Dor::WorkflowObject.initial_workflow(name), opts)
+      Dor::Config.workflow.client.create_workflow(Dor::WorkflowObject.initial_repo(name), pid, name, Dor::WorkflowObject.initial_workflow(name), opts)
       workflows.content(true) # refresh the copy of the workflows datastream
     end
 

--- a/lib/dor/models/workflow_object.rb
+++ b/lib/dor/models/workflow_object.rb
@@ -45,7 +45,7 @@ module Dor
 
     def to_solr(solr_doc = {}, *args)
       super solr_doc, *args
-      solr_doc["#{definition.name}_archived_isi"] = Dor::WorkflowService.count_archived_for_workflow(definition.name)
+      solr_doc["#{definition.name}_archived_isi"] = Dor::Config.workflow.client.count_archived_for_workflow(definition.name)
       solr_doc
     end
 

--- a/lib/dor/services/cleanup_reset_service.rb
+++ b/lib/dor/services/cleanup_reset_service.rb
@@ -18,7 +18,7 @@ module Dor
       last_version = druid_obj.current_version.to_i
 
       # if the current version is still open, avoid this versioned directory
-      if Dor::WorkflowService.get_lifecycle('dor', druid, 'accessioned').nil?
+      if Dor::Config.workflow.client.get_lifecycle('dor', druid, 'accessioned').nil?
         last_version -= 1
       end
       last_version

--- a/lib/dor/services/cleanup_service.rb
+++ b/lib/dor/services/cleanup_service.rb
@@ -69,8 +69,8 @@ module Dor
 
     def self.remove_active_workflows(druid)
       %w(dor sdr).each do |repo|
-        dor_wfs = Dor::WorkflowService.get_workflows(druid, repo)
-        dor_wfs.each { |wf| Dor::WorkflowService.delete_workflow(repo, druid, wf) }
+        dor_wfs = Dor::Config.workflow.client.get_workflows(druid, repo)
+        dor_wfs.each { |wf| Dor::Config.workflow.client.delete_workflow(repo, druid, wf) }
       end
     end
 

--- a/lib/dor/services/merge_service.rb
+++ b/lib/dor/services/merge_service.rb
@@ -68,7 +68,7 @@ module Dor
           unshelve
           unpublish
           Dor::CleanupService.cleanup_by_druid @current_secondary.pid
-          Dor::WorkflowService.archive_active_workflow 'dor', @current_secondary.pid
+          Dor::Config.workflow.client.archive_active_workflow 'dor', @current_secondary.pid
         rescue => e
           @logger.error "Unable to decomission #{@current_secondary.pid} with primary object #{@primary.pid}: #{e.inspect}"
           @logger.error e.backtrace.join("\n")

--- a/spec/dor/config_spec.rb
+++ b/spec/dor/config_spec.rb
@@ -35,7 +35,7 @@ describe Dor::Configuration do
       workflow.url 'http://mynewurl.edu/workflow'
     end
 
-    expect(Dor::WorkflowService.base_url.to_s).to eq 'http://mynewurl.edu/workflow'
+    expect(@config.workflow.client.base_url.to_s).to eq('http://mynewurl.edu/workflow')
   end
 
   it 'adds deprecation warnings for old solrizer configurations' do

--- a/spec/dor/processable_spec.rb
+++ b/spec/dor/processable_spec.rb
@@ -33,15 +33,15 @@ describe Dor::Processable do
   end
 
   it 'should load its content directly from the workflow service' do
-    expect(Dor::WorkflowService).to receive(:get_workflow_xml).with('dor', 'druid:ab123cd4567', nil).once { '<workflows/>' }
+    expect(Dor::Config.workflow.client).to receive(:get_workflow_xml).with('dor', 'druid:ab123cd4567', nil).once { '<workflows/>' }
     expect(@item.workflows.content).to eq('<workflows/>')
   end
 
   it 'should be able to invalidate the cache of its content' do
-    expect(Dor::WorkflowService).to receive(:get_workflow_xml).with('dor', 'druid:ab123cd4567', nil).once { '<workflows/>' }
+    expect(Dor::Config.workflow.client).to receive(:get_workflow_xml).with('dor', 'druid:ab123cd4567', nil).once { '<workflows/>' }
     expect(@item.workflows.content).to eq('<workflows/>')
     expect(@item.workflows.content).to eq('<workflows/>') # should be cached copy
-    expect(Dor::WorkflowService).to receive(:get_workflow_xml).with('dor', 'druid:ab123cd4567', nil).once { '<workflows>with some data</workflows>' }
+    expect(Dor::Config.workflow.client).to receive(:get_workflow_xml).with('dor', 'druid:ab123cd4567', nil).once { '<workflows>with some data</workflows>' }
     # pass refresh flag and should be refreshed copy
     expect(@item.workflows.content(true)).to eq('<workflows>with some data</workflows>')
     expect(@item.workflows.content).to eq('<workflows>with some data</workflows>')
@@ -147,7 +147,7 @@ describe Dor::Processable do
       '
 
       xml = Nokogiri::XML(xml)
-      allow(Dor::WorkflowService).to receive(:query_lifecycle).and_return(xml)
+      allow(Dor::Config.workflow.client).to receive(:query_lifecycle).and_return(xml)
       allow_any_instance_of(Dor::Workflow::Document).to receive(:to_solr).and_return(nil)
       @versionMD = Dor::VersionMetadataDS.from_xml(dsxml)
       allow(@item).to receive(:versionMetadata).and_return(@versionMD)
@@ -172,7 +172,7 @@ describe Dor::Processable do
     end
     it 'should skip the versioning related steps if a new version has not been opened' do
       @item = instantiate_fixture('druid:ab123cd4567', ProcessableOnlyItem)
-      allow(Dor::WorkflowService).to receive(:query_lifecycle).and_return(Nokogiri::XML('<?xml version="1.0" encoding="UTF-8"?>
+      allow(Dor::Config.workflow.client).to receive(:query_lifecycle).and_return(Nokogiri::XML('<?xml version="1.0" encoding="UTF-8"?>
       <lifecycle objectId="druid:gv054hp4128">
       <milestone date="2012-11-06T16:30:03-0800">submitted</milestone>
       <milestone date="2012-11-06T16:35:00-0800">described</milestone>
@@ -244,17 +244,17 @@ describe Dor::Processable do
       </lifecycle>
       '
       xml = Nokogiri::XML(xml)
-      expect(Dor::WorkflowService).to receive(:query_lifecycle).and_return(xml)
+      expect(Dor::Config.workflow.client).to receive(:query_lifecycle).and_return(xml)
       expect(@versionMD).to receive(:current_version_id).and_return('4')
       expect(@item.status).to eq('v4 In accessioning (described, published)')
     end
     it 'should generate a status string' do
-      expect(Dor::WorkflowService).to receive(:query_lifecycle).and_return(@gv054hp4128)
+      expect(Dor::Config.workflow.client).to receive(:query_lifecycle).and_return(@gv054hp4128)
       expect(@versionMD).to receive(:current_version_id).and_return('3')
       expect(@item.status).to eq('v3 In accessioning (described, published)')
     end
     it 'should generate a status string' do
-      expect(Dor::WorkflowService).to receive(:query_lifecycle).and_return(@gv054hp4128)
+      expect(Dor::Config.workflow.client).to receive(:query_lifecycle).and_return(@gv054hp4128)
       expect(@versionMD).to receive(:current_version_id).and_return('3')
       expect(@item.status).to eq('v3 In accessioning (described, published)')
     end
@@ -284,7 +284,7 @@ describe Dor::Processable do
       @versionMD = double(Dor::VersionMetadataDS)
       allow_any_instance_of(Dor::Workflow::Document).to receive(:to_solr).and_return(nil)
       expect(@item).to receive(:versionMetadata).and_return(@versionMD)
-      expect(Dor::WorkflowService).to receive(:query_lifecycle).and_return(@xml)
+      expect(Dor::Config.workflow.client).to receive(:query_lifecycle).and_return(@xml)
     end
 
     it 'should handle a v2 accessioned object' do
@@ -308,7 +308,7 @@ describe Dor::Processable do
       allow(item).to receive(:admin_policy_object) { apo }
       expect(Dor::WorkflowObject).to receive(:initial_workflow).and_return('<xml/>')
       expect(Dor::WorkflowObject).to receive(:initial_repo).and_return('dor')
-      expect(Dor::WorkflowService).to receive(:create_workflow).with('dor', 'druid:ab123cd4567', 'accessionWF', '<xml/>', {:create_ds => true, :lane_id => 'fast'})
+      expect(Dor::Config.workflow.client).to receive(:create_workflow).with('dor', 'druid:ab123cd4567', 'accessionWF', '<xml/>', {:create_ds => true, :lane_id => 'fast'})
       item.create_workflow('accessionWF')
     end
   end

--- a/spec/dor/rights_metadata_spec.rb
+++ b/spec/dor/rights_metadata_spec.rb
@@ -8,7 +8,7 @@ describe Dor::RightsMetadataDS do
     @item = instantiate_fixture('druid:bb046xn0881', Dor::Item)
     allow(Dor::Item).to receive(:find).with(@item.pid).and_return(@item)
     allow(@item).to receive(:workflows).and_return(double)
-    allow(Dor::WorkflowService).to receive(:get_milestones).and_return([])
+    allow(Dor::Config.workflow.client).to receive(:get_milestones).and_return([])
   end
 
   it '#new' do

--- a/spec/dor/versionable_spec.rb
+++ b/spec/dor/versionable_spec.rb
@@ -26,9 +26,9 @@ describe Dor::Versionable do
 
     context 'normal behavior' do
       before(:each) do
-        expect(Dor::WorkflowService).to receive(:get_lifecycle).with('dor', dr, 'accessioned').and_return(true)
-        expect(Dor::WorkflowService).to receive(:get_active_lifecycle).with('dor', dr, 'opened').and_return(nil)
-        expect(Dor::WorkflowService).to receive(:get_active_lifecycle).with('dor', dr, 'submitted').and_return(nil)
+        expect(Dor::Config.workflow.client).to receive(:get_lifecycle).with('dor', dr, 'accessioned').and_return(true)
+        expect(Dor::Config.workflow.client).to receive(:get_active_lifecycle).with('dor', dr, 'opened').and_return(nil)
+        expect(Dor::Config.workflow.client).to receive(:get_active_lifecycle).with('dor', dr, 'submitted').and_return(nil)
         expect(Sdr::Client).to receive(:current_version).and_return(1)
         expect(obj).to receive(:initialize_workflow).with('versioningWF')
         allow(obj).to receive(:new_object?).and_return(false)
@@ -82,27 +82,27 @@ describe Dor::Versionable do
 
     context 'error handling' do
       it 'raises an exception if it the object has not yet been accessioned' do
-        expect(Dor::WorkflowService).to receive(:get_lifecycle).with('dor', dr, 'accessioned').and_return(false)
+        expect(Dor::Config.workflow.client).to receive(:get_lifecycle).with('dor', dr, 'accessioned').and_return(false)
         expect { obj.open_new_version }.to raise_error(Dor::Exception, 'Object net yet accessioned')
       end
 
       it 'raises an exception if the object has already been opened' do
-        expect(Dor::WorkflowService).to receive(:get_lifecycle).with('dor', dr, 'accessioned').and_return(true)
-        expect(Dor::WorkflowService).to receive(:get_active_lifecycle).with('dor', dr, 'opened').and_return(Time.new)
+        expect(Dor::Config.workflow.client).to receive(:get_lifecycle).with('dor', dr, 'accessioned').and_return(true)
+        expect(Dor::Config.workflow.client).to receive(:get_active_lifecycle).with('dor', dr, 'opened').and_return(Time.new)
         expect { obj.open_new_version }.to raise_error(Dor::Exception, 'Object already opened for versioning')
       end
 
       it 'raises an exception if the object is still being accessioned' do
-        expect(Dor::WorkflowService).to receive(:get_lifecycle).with('dor', dr, 'accessioned').and_return(true)
-        expect(Dor::WorkflowService).to receive(:get_active_lifecycle).with('dor', dr, 'opened').and_return(nil)
-        expect(Dor::WorkflowService).to receive(:get_active_lifecycle).with('dor', dr, 'submitted').and_return(Time.new)
+        expect(Dor::Config.workflow.client).to receive(:get_lifecycle).with('dor', dr, 'accessioned').and_return(true)
+        expect(Dor::Config.workflow.client).to receive(:get_active_lifecycle).with('dor', dr, 'opened').and_return(nil)
+        expect(Dor::Config.workflow.client).to receive(:get_active_lifecycle).with('dor', dr, 'submitted').and_return(Time.new)
         expect { obj.open_new_version }.to raise_error(Dor::Exception, 'Object currently being accessioned')
       end
 
       it "raises an exception if SDR's current version is greater than the current version" do
-        expect(Dor::WorkflowService).to receive(:get_lifecycle).with('dor', dr, 'accessioned').and_return(true)
-        expect(Dor::WorkflowService).to receive(:get_active_lifecycle).with('dor', dr, 'opened').and_return(nil)
-        expect(Dor::WorkflowService).to receive(:get_active_lifecycle).with('dor', dr, 'submitted').and_return(nil)
+        expect(Dor::Config.workflow.client).to receive(:get_lifecycle).with('dor', dr, 'accessioned').and_return(true)
+        expect(Dor::Config.workflow.client).to receive(:get_active_lifecycle).with('dor', dr, 'opened').and_return(nil)
+        expect(Dor::Config.workflow.client).to receive(:get_active_lifecycle).with('dor', dr, 'submitted').and_return(nil)
         expect(Sdr::Client).to receive(:current_version).and_return(3)
         expect { obj.open_new_version }.to raise_error(Dor::Exception, 'Cannot sync to a version greater than current: 1, requested 3')
       end
@@ -121,12 +121,12 @@ describe Dor::Versionable do
 
     it 'sets tag and description if passed in as optional paramaters' do
       allow(vmd_ds).to receive(:pid).and_return('druid:ab123cd4567')
-      allow(Dor::WorkflowService).to receive(:get_active_lifecycle).and_return(true, false)
+      allow(Dor::Config.workflow.client).to receive(:get_active_lifecycle).and_return(true, false)
 
       # Stub out calls to update and archive workflow
-      allow(Dor::WorkflowService).to receive(:update_workflow_status)
+      allow(Dor::Config.workflow.client).to receive(:update_workflow_status)
 
-      expect(Dor::WorkflowService).to receive(:close_version).with('dor', dr , true)
+      expect(Dor::Config.workflow.client).to receive(:close_version).with('dor', dr , true)
 
       allow(obj).to receive(:initialize_workflow)
 
@@ -149,13 +149,13 @@ describe Dor::Versionable do
 
     context 'error handling' do
       it 'raises an exception if the object has not been opened for versioning' do
-        expect(Dor::WorkflowService).to receive(:get_active_lifecycle).with('dor', dr, 'opened').and_return(nil)
+        expect(Dor::Config.workflow.client).to receive(:get_active_lifecycle).with('dor', dr, 'opened').and_return(nil)
         expect { obj.close_version }.to raise_error(Dor::Exception, 'Trying to close version on an object not opened for versioning')
       end
 
       it 'raises an exception if the object has already has an active instance of accesssionWF' do
-        expect(Dor::WorkflowService).to receive(:get_active_lifecycle).with('dor', dr, 'opened').and_return(Time.new)
-        expect(Dor::WorkflowService).to receive(:get_active_lifecycle).with('dor', dr, 'submitted').and_return(true)
+        expect(Dor::Config.workflow.client).to receive(:get_active_lifecycle).with('dor', dr, 'opened').and_return(Time.new)
+        expect(Dor::Config.workflow.client).to receive(:get_active_lifecycle).with('dor', dr, 'submitted').and_return(true)
         expect { obj.submit_version }.to raise_error(Dor::Exception, 'accessionWF already created for versioned object')
       end
 
@@ -167,18 +167,18 @@ describe Dor::Versionable do
   end
   describe 'allows_modification?' do
     it 'should allow modification if the object hasnt been submitted' do
-      allow(Dor::WorkflowService).to receive(:get_lifecycle).and_return(false)
+      allow(Dor::Config.workflow.client).to receive(:get_lifecycle).and_return(false)
       expect(obj.allows_modification?).to be_truthy
     end
     it 'should allow modification if there is an open version' do
-      allow(Dor::WorkflowService).to receive(:get_lifecycle).and_return(true)
+      allow(Dor::Config.workflow.client).to receive(:get_lifecycle).and_return(true)
       allow(obj).to receive(:new_version_open?).and_return(true)
       expect(obj.allows_modification?).to be_truthy
     end
     it 'should allow modification if the item has sdr-ingest-transfer set to hold' do
-      allow(Dor::WorkflowService).to receive(:get_lifecycle).and_return(true)
+      allow(Dor::Config.workflow.client).to receive(:get_lifecycle).and_return(true)
       allow(obj).to receive(:new_version_open?).and_return(false)
-      allow(Dor::WorkflowService).to receive(:get_workflow_status).and_return('hold')
+      allow(Dor::Config.workflow.client).to receive(:get_workflow_status).and_return('hold')
       expect(obj.allows_modification?).to be_truthy
     end
   end

--- a/spec/dor/workflow_ds_spec.rb
+++ b/spec/dor/workflow_ds_spec.rb
@@ -34,12 +34,12 @@ describe Dor::WorkflowDs do
           datetime="2012-11-06T16:19:15-0800" status="completed" name="descriptive-metadata"/>
         <process version="2" elapsed="0.0" archived="true" attempts="2"
           datetime="2012-11-06T16:19:16-0800" status="completed" name="content-metadata"/>'
-      allow(Dor::WorkflowService).to receive(:get_workflow_xml).and_return(xml)
+      allow(Dor::Config.workflow.client).to receive(:get_workflow_xml).and_return(xml)
       accessionWF = @item.workflows['accessionWF']
       expect(accessionWF).not_to be_nil
     end
     it 'should return nil if the xml is empty' do
-      allow(Dor::WorkflowService).to receive(:get_workflow_xml).and_return('')
+      allow(Dor::Config.workflow.client).to receive(:get_workflow_xml).and_return('')
       expect(@item.workflows['accessionWF']).to be_nil
     end
   end
@@ -69,16 +69,16 @@ describe Dor::WorkflowDs do
            datetime="2012-11-06T16:19:15-0800" status="completed" name="descriptive-metadata"/>
          <process version="2" elapsed="0.0" archived="true" attempts="2"
            datetime="2012-11-06T16:19:16-0800" status="completed" name="content-metadata"/>'
-      allow(Dor::WorkflowService).to receive(:get_workflow_xml).and_return(xml)
+      allow(Dor::Config.workflow.client).to receive(:get_workflow_xml).and_return(xml)
       accessionWF = @item.workflows.get_workflow 'accessionWF'
       expect(accessionWF).not_to be_nil
     end
     it 'should return nil if the xml is empty' do
-      allow(Dor::WorkflowService).to receive(:get_workflow_xml).and_return('')
+      allow(Dor::Config.workflow.client).to receive(:get_workflow_xml).and_return('')
       expect(@item.workflows.get_workflow('accessionWF')).to be_nil
     end
     it 'should request the workflow for a different repository if one is specified' do
-      expect(Dor::WorkflowService).to receive(:get_workflow_xml).with('sdr', 'druid:ab123cd4567', 'accessionWF').and_return('')
+      expect(Dor::Config.workflow.client).to receive(:get_workflow_xml).with('sdr', 'druid:ab123cd4567', 'accessionWF').and_return('')
       @item.workflows.get_workflow('accessionWF', 'sdr')
     end
   end

--- a/spec/dor/workflow_object_spec.rb
+++ b/spec/dor/workflow_object_spec.rb
@@ -23,7 +23,7 @@ describe Dor::WorkflowObject do
     end
 
     it 'indexes the number of archived objects for the workflow' do
-      expect(Dor::WorkflowService).to receive(:count_archived_for_workflow).and_return(5)
+      expect(Dor::Config.workflow.client).to receive(:count_archived_for_workflow).and_return(5)
       expect(@item.to_solr).to include 'accessionWF_archived_isi' => 5
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ require 'nokogiri'
 
 require 'dor_config'
 require 'vcr'
+require 'retries'
 
 # ::ENABLE_SOLR_UPDATES = true
 


### PR DESCRIPTION
This is the same pattern as #178, tweaked to work with the existing `Dor::WorkflowService` singleton. This could allow many downstream consumers to be unaffected by the singleton => instantiatable migration.