### PR TITLE
Extract calls to SDR into the Sdr::Client class

### DIFF
--- a/lib/dor-services.rb
+++ b/lib/dor-services.rb
@@ -2,6 +2,7 @@ require 'active_fedora'
 require 'active_support/core_ext/module/attribute_accessors'
 require 'modsulator'
 require 'nokogiri-pretty'
+require 'dor/utils/sdr_client'
 
 module Dor
   @@registered_classes = {}

--- a/lib/dor/models/itemizable.rb
+++ b/lib/dor/models/itemizable.rb
@@ -10,7 +10,6 @@ module Dor
     end
 
     DIFF_FILENAME = 'cm_inv_diff'
-    DIFF_QUERY = DIFF_FILENAME.tr('_', '-')
 
     # Deletes all cm_inv_diff files in the workspace for the Item
     def clear_diff_cache
@@ -31,25 +30,13 @@ module Dor
       if Dor::Config.stacks.local_workspace_root.nil?
         raise Dor::ParameterError, 'Missing Dor::Config.stacks.local_workspace_root'
       end
-      unless %w(all shelve preserve publish).include?(subset.to_s)
-        raise Dor::ParameterError, "Invalid subset value: #{subset}"
-      end
 
-      # fetch content metadata inventory difference from SDR
-      if Dor::Config.dor_services.rest_client.nil?
-        raise Dor::ParameterError, 'Missing Dor::Config.dor_services.rest_client'
-      end
-      sdr_client = Dor::Config.dor_services.rest_client
       current_content = datastreams['contentMetadata'].content
       if current_content.nil?
         raise Dor::Exception, 'Missing contentMetadata datastream'
       end
-      query_string = { :subset => subset.to_s }
-      query_string[:version] = version.to_s unless version.nil?
-      query_string = URI.encode_www_form(query_string)
-      sdr_query = "sdr/objects/#{pid}/#{DIFF_QUERY}?#{query_string}"
-      response = sdr_client[sdr_query].post(current_content, :content_type => 'application/xml')
-      response
+
+      Sdr::Client.get_content_diff(druid, current_content, subset, version)
     end
   end
 end

--- a/lib/dor/models/shelvable.rb
+++ b/lib/dor/models/shelvable.rb
@@ -25,8 +25,7 @@ module Dor
     # retrieve the differences between the current contentMetadata and the previously ingested version
     # (filtering to select only the files that should be shelved to stacks)
     def get_shelve_diff
-      inventory_diff_xml = get_content_diff(:shelve)
-      inventory_diff = Moab::FileInventoryDifference.parse(inventory_diff_xml)
+      inventory_diff = get_content_diff(:shelve)
       shelve_diff = inventory_diff.group_difference('content')
       shelve_diff
     end

--- a/lib/dor/models/versionable.rb
+++ b/lib/dor/models/versionable.rb
@@ -1,5 +1,3 @@
-require 'dor/utils/sdr_client'
-
 module Dor
   module Versionable
     extend ActiveSupport::Concern

--- a/lib/dor/services/sdr_ingest_service.rb
+++ b/lib/dor/services/sdr_ingest_service.rb
@@ -44,12 +44,7 @@ module Dor
     # @param [String] druid The object identifier
     # @return [Moab::SignatureCatalog] the catalog of all files previously ingested
     def self.get_signature_catalog(druid)
-      sdr_client = Dor::Config.dor_services.rest_client
-      url = "sdr/objects/#{druid}/manifest/signatureCatalog.xml"
-      response = sdr_client[url].get
-      Moab::SignatureCatalog.parse(response)
-    rescue RestClient::ResourceNotFound
-      Moab::SignatureCatalog.new(:digital_object_id => druid, :version_id => 0)
+      Sdr::Client.get_signature_catalog(druid)
     end
 
     # @param [Dor::Item] dor_item The representation of the digital object

--- a/lib/dor/services/technical_metadata_service.rb
+++ b/lib/dor/services/technical_metadata_service.rb
@@ -48,8 +48,7 @@ module Dor
     # @param [Dor::Item] dor_item The DOR item being processed by the technical metadata robot
     # @return [FileGroupDifference] The differences between two versions of a group of files
     def self.get_content_group_diff(dor_item)
-      inventory_diff_xml = dor_item.get_content_diff('all')
-      inventory_diff = Moab::FileInventoryDifference.parse(inventory_diff_xml)
+      inventory_diff = dor_item.get_content_diff('all')
       inventory_diff.group_difference('content')
     end
 
@@ -77,11 +76,7 @@ module Dor
     # @return [String] The technicalMetadata datastream from the previous version of the digital object (fetched from SDR storage)
     #   The data is updated to the latest format.
     def self.get_sdr_technical_metadata(druid)
-      begin
-        sdr_techmd = get_sdr_metadata(druid, 'technicalMetadata')
-      rescue RestClient::ResourceNotFound
-        return nil
-      end
+      sdr_techmd = get_sdr_metadata(druid, 'technicalMetadata')
       return sdr_techmd if sdr_techmd =~ /<technicalMetadata/
       return ::JhoveService.new.upgrade_technical_metadata(sdr_techmd) if sdr_techmd =~ /<jhove/
       nil
@@ -103,10 +98,7 @@ module Dor
     # @param [String] dsname The identifier of the metadata datastream
     # @return [String] The datastream contents from the previous version of the digital object (fetched from SDR storage)
     def self.get_sdr_metadata(druid, dsname)
-      sdr_client = Dor::Config.dor_services.rest_client
-      url = "sdr/objects/#{druid}/metadata/#{dsname}.xml"
-
-      sdr_client[url].get
+      Sdr::Client.get_sdr_metadata(druid, dsname)
     end
 
     # @param [DruidTools::Druid] druid A wrapper class for the druid identifier.  Used to generate paths

--- a/lib/dor/utils/sdr_client.rb
+++ b/lib/dor/utils/sdr_client.rb
@@ -1,12 +1,11 @@
+require 'moab'
 module Sdr
-  module Client
+  class Client
     class << self
-
       # @param [String] druid id of the object you want the version of
       # @return [Integer] the current version from SDR
       def current_version(druid)
-        sdr_client = Dor::Config.dor_services.rest_client
-        xml = sdr_client["sdr/objects/#{druid}/current_version"].get
+        xml = client["objects/#{druid}/current_version"].get
 
         begin
           doc = Nokogiri::XML xml
@@ -17,6 +16,45 @@ module Sdr
         end
       end
 
+      # @param [String] dsname The identifier of the metadata datastream
+      # @return [String] The datastream contents from the previous version of the digital object (fetched from SDR storage)
+      def get_sdr_metadata(druid, dsname)
+        client["objects/#{druid}/metadata/#{dsname}.xml"].get
+      rescue RestClient::ResourceNotFound
+        return nil
+      end
+
+      # @param [String] druid The object identifier
+      # @return [Moab::SignatureCatalog] the catalog of all files previously ingested
+      def get_signature_catalog(druid)
+        response = client["objects/#{druid}/manifest/signatureCatalog.xml"].get
+        Moab::SignatureCatalog.parse(response)
+      rescue RestClient::ResourceNotFound
+        Moab::SignatureCatalog.new(:digital_object_id => druid, :version_id => 0)
+      end
+
+      def get_content_diff(druid, current_content, subset = :all, version = nil)
+        unless %w(all shelve preserve publish).include?(subset.to_s)
+          raise Dor::ParameterError, "Invalid subset value: #{subset}"
+        end
+
+        query_string = { :subset => subset.to_s }
+        query_string[:version] = version.to_s unless version.nil?
+        query_string = URI.encode_www_form(query_string)
+        sdr_query = "objects/#{druid}/cm-inv-diff?#{query_string}"
+        response = client[sdr_query].post(current_content, :content_type => 'application/xml')
+        Moab::FileInventoryDifference.parse(response)
+      end
+
+      def client
+        if Dor::Config.sdr.url
+          Dor::Config.sdr.rest_client
+        elsif Dor::Config.dor_services.url
+          Dor::Config.dor_services.rest_client['v1/sdr']
+        else
+          raise Dor::ParameterError, 'Missing Dor::Config.sdr and/or Dor::Config.dor_services configuration'
+        end
+      end
     end
   end
 end

--- a/script/manual_integration.rb
+++ b/script/manual_integration.rb
@@ -116,7 +116,7 @@ class MergeIntegrationTest
   def publish_shelve
     @pids.map {|p| "druid:#{p}"}.each do |pid|
       i = Dor::Item.find pid
-      change_manifest = Dor::Versioning::FileInventoryDifference.new(i.get_content_diff(:shelve))
+      change_manifest = i.get_content_diff(:shelve)
       Dor::DigitalStacksService.shelve_to_stacks i.pid, change_manifest.file_sets(:added, :content)
       i.publish_metadata
     end

--- a/spec/dor/itemizable_spec.rb
+++ b/spec/dor/itemizable_spec.rb
@@ -18,9 +18,4 @@ describe Dor::Itemizable do
   it 'has a contentMetadata datastream' do
     expect(@item.datastreams['contentMetadata']).to be_a(Dor::ContentMetadataDS)
   end
-
-  it 'should retrieve a content diff' do
-    skip 'write a diff test'
-  end
-
 end

--- a/spec/dor/sdr_ingest_service_spec.rb
+++ b/spec/dor/sdr_ingest_service_spec.rb
@@ -127,17 +127,6 @@ describe Dor::SdrIngestService do
     end
   end
 
-  specify 'get_signature_catalog' do
-    druid = 'druid:zz000zz0000'
-    resource = Dor::Config.dor_services.rest_client["sdr/objects/#{druid}/manifest/signatureCatalog.xml"]
-    stub_request(:get, resource.url).to_return(:body => '<signatureCatalog objectId="druid:zz000zz0000" versionId="0" catalogDatetime="" fileCount="0" byteCount="0" blockCount="0"/>')
-    catalog = Dor::SdrIngestService.get_signature_catalog(druid)
-    # p catalog
-    # p catalog.to_xml
-    expect(catalog.to_xml).to match(/<signatureCatalog/)
-    expect(catalog.version_id).to eq 0
-  end
-
   specify 'extract_datastreams' do
     dor_item = double('workitem')
     metadata_dir = double('metadata dir')

--- a/spec/dor/shelvable_spec.rb
+++ b/spec/dor/shelvable_spec.rb
@@ -47,7 +47,7 @@ describe Dor::Shelvable do
       workitem = ShelvableItem.new(:pid => druid)
       # read in a FileInventoryDifference manifest from the fixtures area
       xml_pathname = Pathname('spec').join('fixtures', 'content_diff_reports', 'jq937jp0017-v1-v2.xml')
-      expect(workitem).to receive(:get_content_diff).with(:shelve).and_return(xml_pathname.read)
+      expect(workitem).to receive(:get_content_diff).with(:shelve).and_return(Moab::FileInventoryDifference.parse(xml_pathname.read))
       result = workitem.get_shelve_diff
       expect(result.to_xml).to be_equivalent_to(<<-EOF
         <fileGroupDifference groupId="content" differenceCount="3" identical="3" copyadded="0" copydeleted="0" renamed="0" modified="1" added="0" deleted="2">

--- a/spec/dor/technical_metadata_service_spec.rb
+++ b/spec/dor/technical_metadata_service_spec.rb
@@ -86,7 +86,7 @@ describe Dor::TechnicalMetadataService do
       )
       inventory_diff.group_differences << group_diff
       dor_item = double(Dor::Item)
-      allow(dor_item).to receive(:get_content_diff).with('all').and_return(inventory_diff.to_xml)
+      allow(dor_item).to receive(:get_content_diff).with('all').and_return(inventory_diff)
       content_group_diff = Dor::TechnicalMetadataService.get_content_group_diff(dor_item)
       expect(content_group_diff.to_xml).to eq(group_diff.to_xml)
     end
@@ -119,7 +119,7 @@ describe Dor::TechnicalMetadataService do
 
   specify 'Dor::TechnicalMetadataService.get_sdr_technical_metadata' do
     druid = 'druid:du000ps9999'
-    allow(Dor::TechnicalMetadataService).to receive(:get_sdr_metadata).with(druid, 'technicalMetadata').and_raise(RestClient::ResourceNotFound)
+    allow(Sdr::Client).to receive(:get_sdr_metadata).with(druid, 'technicalMetadata').and_return(nil)
     sdr_techmd = Dor::TechnicalMetadataService.get_sdr_technical_metadata(druid)
     expect(sdr_techmd).to be_nil
 
@@ -156,12 +156,6 @@ describe Dor::TechnicalMetadataService do
     allow(jhove_service).to receive(:upgrade_technical_metadata).and_return('upgraded techmd')
     dor_techmd = Dor::TechnicalMetadataService.get_dor_technical_metadata(dor_item)
     expect(dor_techmd).to eq('upgraded techmd')
-  end
-
-  specify 'Dor::TechnicalMetadataService.get_sdr_metadata' do
-    stub_request(:get, "#{Dor::Config.dor_services.url}/sdr/objects/druid:ab123cd4567/metadata/technicalMetadata.xml").to_return(:body => '<technicalMetadata/>')
-    response = Dor::TechnicalMetadataService.get_sdr_metadata('druid:ab123cd4567', 'technicalMetadata')
-    expect(response).to eq('<technicalMetadata/>')
   end
 
   specify 'Dor::TechnicalMetadataService.get_new_technical_metadata' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,7 @@ module Dor::SpecHelpers
       indexing_svc.log                 'indexing_svc.log.test'
 
       dor_services do
-        url 'http://localhost/dor/v1'
+        url 'http://localhost/dor'
       end
     end
     allow(ActiveFedora).to receive(:fedora).and_return(double('frepo').as_null_object)  # must be used in per-request context: :each not :all

--- a/spec/utils/sdr_client_spec.rb
+++ b/spec/utils/sdr_client_spec.rb
@@ -3,27 +3,95 @@ require 'dor/utils/sdr_client'
 
 describe Sdr::Client do
   describe '.get_current_version' do
-    let(:dor_services_url) { Dor::Config.dor_services.url }
-
     it 'returns the current of the object from SDR' do
-      stub_request(:get, "#{dor_services_url}/sdr/objects/druid:ab123cd4567/current_version")
+      stub_request(:get, Sdr::Client.client['objects/druid:ab123cd4567/current_version'].url)
         .to_return(:body => '<currentVersion>2</currentVersion>')
       expect(Sdr::Client.current_version('druid:ab123cd4567')).to eq 2
     end
 
     context 'raises an exception if the xml' do
       it 'has the wrong root element' do
-        stub_request(:get, "#{dor_services_url}/sdr/objects/druid:ab123cd4567/current_version")
+        stub_request(:get, Sdr::Client.client['objects/druid:ab123cd4567/current_version'].url)
           .to_return(:body => '<wrongRoot>2</wrongRoot>')
         expect{ Sdr::Client.current_version('druid:ab123cd4567') }
           .to raise_error(Exception, 'Unable to parse XML from SDR current_version API call: <wrongRoot>2</wrongRoot>')
       end
 
       it 'does not contain an Integer as its text' do
-        stub_request(:get, "#{dor_services_url}/sdr/objects/druid:ab123cd4567/current_version")
+        stub_request(:get, Sdr::Client.client['objects/druid:ab123cd4567/current_version'].url)
           .to_return(:body => '<currentVersion>two</currentVersion>')
         expect{ Sdr::Client.current_version('druid:ab123cd4567') }
           .to raise_error(Exception, 'Unable to parse XML from SDR current_version API call: <currentVersion>two</currentVersion>')
+      end
+    end
+  end
+
+  describe '.get_sdr_metadata' do
+    it 'fetches the datastream from SDR' do
+      stub_request(:get, Sdr::Client.client["objects/druid:ab123cd4567/metadata/technicalMetadata.xml"].url).to_return(:body => '<technicalMetadata/>')
+      response = Sdr::Client.get_sdr_metadata('druid:ab123cd4567', 'technicalMetadata')
+      expect(response).to eq('<technicalMetadata/>')
+    end
+  end
+
+  describe '.get_signature_catalog' do
+    let(:druid) { 'druid:zz000zz0000' }
+    it 'fetches the signature catalog from SDR' do
+      resource = Sdr::Client.client["objects/#{druid}/manifest/signatureCatalog.xml"]
+      stub_request(:get, resource.url).to_return(:body => '<signatureCatalog objectId="druid:zz000zz0000" versionId="0" catalogDatetime="" fileCount="0" byteCount="0" blockCount="0"/>')
+
+      catalog = Sdr::Client.get_signature_catalog(druid)
+      expect(catalog.to_xml).to match(/<signatureCatalog/)
+      expect(catalog.version_id).to eq 0
+    end
+  end
+
+  describe '.get_content_diff' do
+    let(:druid) { 'druid:zz000zz0000' }
+
+    it 'fetches the file inventory difference from SDR' do
+      resource = Sdr::Client.client["objects/#{druid}/cm-inv-diff?subset=all"]
+      stub_request(:post, resource.url).to_return(:body => '<fileInventoryDifference />')
+
+      inventory_difference = Sdr::Client.get_content_diff(druid, '')
+
+      expect(inventory_difference.to_xml).to match(/<fileInventoryDifference/)
+    end
+
+    it 'rejects invalid subset parameters' do
+      expect { Sdr::Client.get_content_diff(druid, '', 'bad') }.to raise_error Dor::ParameterError
+    end
+  end
+
+  describe '.client' do
+    context 'with SDR configuration' do
+      before do
+        allow(Dor::Config.sdr).to receive(:url).and_return('http://example.com')
+      end
+
+      it 'is configured to use SDR' do
+        expect(Sdr::Client.client.url).to eq 'http://example.com'
+      end
+    end
+
+    context 'with DOR services configuration' do
+      before do
+        allow(Dor::Config.sdr).to receive(:url).and_return(nil)
+      end
+
+      it 'is configured to use SDR' do
+        expect(Sdr::Client.client.url).to eq Dor::Config.dor_services.rest_client['v1/sdr'].url
+      end
+    end
+
+    context 'without any configuration' do
+      before do
+        allow(Dor::Config.sdr).to receive(:url).and_return(nil)
+        allow(Dor::Config.dor_services).to receive(:url).and_return(nil)
+      end
+
+      it 'raises an exception' do
+        expect { Sdr::Client.client }.to raise_error Dor::ParameterError
       end
     end
   end


### PR DESCRIPTION
This has the secondary benefit of restoring backwards compatibility to clients that have configured SDR, but have not configured a url for the dor services app.