### PR TITLE
use create_workflow rather than deprecated initialize_workflow

### DIFF
--- a/lib/dor/models/governable.rb
+++ b/lib/dor/models/governable.rb
@@ -10,7 +10,7 @@ module Dor
     end
 
     def initiate_apo_workflow(name)
-      initialize_workflow(name, !self.new_object?)
+      create_workflow(name, !self.new_object?)
     end
 
     # Returns the default lane_id from the item's APO.  Will return 'default' if the item does not have

--- a/lib/dor/models/releaseable.rb
+++ b/lib/dor/models/releaseable.rb
@@ -20,7 +20,7 @@ module Dor
 
       # Save item to dor so the robots work with the latest data
       save
-      initialize_workflow('releaseWF')
+      create_workflow('releaseWF')
     end
 
     # Generate XML structure for inclusion to Purl

--- a/lib/dor/models/versionable.rb
+++ b/lib/dor/models/versionable.rb
@@ -12,7 +12,7 @@ module Dor
     # Increments the version number and initializes versioningWF for the object
     # @param [Hash] opts optional params
     # @option opts [Boolean] :assume_accessioned If true, does not check whether object has been accessioned.
-    # @option opts [Boolean] :create_workflows_ds If false, initialize_workflow() will not initialize the workflows datastream.
+    # @option opts [Boolean] :create_workflows_ds If false, create_workflow() will not initialize the workflows datastream.
     # @option opts [Hash] :vers_md_upd_info If present, used to add to the events datastream and set the desc and significance on the versionMetadata datastream
     # @raise [Dor::Exception] if the object hasn't been accessioned, or if a version is already opened
     def open_new_version(opts = {})
@@ -32,9 +32,9 @@ module Dor
       k = :create_workflows_ds
       if opts.key?(k)
         # During local development, Hydrus (or another app w/ local Fedora) does not want to initialize workflows datastream.
-        initialize_workflow('versioningWF', opts[k])
+        create_workflow('versioningWF', opts[k])
       else
-        initialize_workflow('versioningWF')
+        create_workflow('versioningWF')
       end
 
       vmd_upd_info = opts[:vers_md_upd_info]

--- a/lib/dor/services/registration_service.rb
+++ b/lib/dor/services/registration_service.rb
@@ -127,7 +127,7 @@ module Dor
         workflow_priority = params[:workflow_priority] ? params[:workflow_priority].to_i : 0
 
         Array(params[:seed_datastream]).each { |datastream_name| new_item.build_datastream(datastream_name) }
-        Array(params[:initiate_workflow]).each { |workflow_id| new_item.initialize_workflow(workflow_id, !new_item.new_object?, workflow_priority)}
+        Array(params[:initiate_workflow]).each { |workflow_id| new_item.create_workflow(workflow_id, !new_item.new_object?, workflow_priority)}
 
         new_item.assert_content_model
 

--- a/lib/dor/services/sdr_ingest_service.rb
+++ b/lib/dor/services/sdr_ingest_service.rb
@@ -36,7 +36,7 @@ module Dor
       bagger.create_tagfiles
       verify_bag_structure(bag_dir)
       # Now bootstrap SDR workflow. but do not create the workflows datastream
-      dor_item.initialize_workflow('sdrIngestWF', false)
+      dor_item.create_workflow('sdrIngestWF', false)
     rescue Exception => e
       raise LyberCore::Exceptions::ItemError.new(druid, 'Export failure', e)
     end

--- a/spec/dor/governable_spec.rb
+++ b/spec/dor/governable_spec.rb
@@ -227,9 +227,9 @@ describe Dor::Governable do
   end
 
   describe 'initiate_apo_workflow' do
-    it 'calls Processable.initialize_workflow without creating a datastream when the object is new' do
+    it 'calls Processable.create_workflow without creating a datastream when the object is new' do
       i = GovernableItem.new
-      expect(i).to receive(:initialize_workflow).with('accessionWF', false)
+      expect(i).to receive(:create_workflow).with('accessionWF', false)
       i.initiate_apo_workflow('accessionWF')
     end
   end
@@ -276,9 +276,9 @@ describe Dor::Governable do
   end
 
   describe 'initiate_apo_workflow' do
-    it 'calls Processable.initialize_workflow without creating a datastream when the object is new' do
+    it 'calls Processable.create_workflow without creating a datastream when the object is new' do
       i = GovernableItem.new
-      expect(i).to receive(:initialize_workflow).with('accessionWF', false)
+      expect(i).to receive(:create_workflow).with('accessionWF', false)
       i.initiate_apo_workflow('accessionWF')
     end
   end

--- a/spec/dor/registration_service_spec.rb
+++ b/spec/dor/registration_service_spec.rb
@@ -294,7 +294,7 @@ describe Dor::RegistrationService do
         expect(obj.label).to eq('a' * 254)
       end
       it 'sets workflow priority when passed in' do
-        expect_any_instance_of(Dor::Item).to receive(:initialize_workflow).with('digitizationWF', false, 50)
+        expect_any_instance_of(Dor::Item).to receive(:create_workflow).with('digitizationWF', false, 50)
         @params[:workflow_priority] = 50
         @params[:initiate_workflow] = 'digitizationWF'
         Dor::RegistrationService.register_object(@params)

--- a/spec/dor/releaseable_spec.rb
+++ b/spec/dor/releaseable_spec.rb
@@ -231,13 +231,13 @@ describe 'Adding release nodes', :vcr do
   describe 'Adding tags and workflows' do
     it 'should release an item with one release tag supplied' do
       allow(@item).to receive(:save).and_return(true) # stud out the true in that it we lack a connection to solr
-      expect(@item).to receive(:initialize_workflow).with('releaseWF') # Make sure releaseWF is called
+      expect(@item).to receive(:create_workflow).with('releaseWF') # Make sure releaseWF is called
       expect(@item).to receive(:add_release_node).once
       expect(@item.add_release_nodes_and_start_releaseWF({:release => true, :what => 'self', :who => 'carrickr', :to => 'FRDA'})).to eq(nil) # Should run and return void
     end
     it 'should release an item with multiple release tags supplied' do
       allow(@item).to receive(:save).and_return(true) # stud out the true in that it we lack a connection to solr
-      expect(@item).to receive(:initialize_workflow).with('releaseWF') # Make sure releaseWF is called
+      expect(@item).to receive(:create_workflow).with('releaseWF') # Make sure releaseWF is called
       expect(@item).to receive(:add_release_node).twice
       tags = [{:release => true, :what => 'self', :who => 'carrickr', :to => 'FRDA'}, {:release => true, :what => 'self', :who => 'carrickr', :to => 'Revs'}]
       expect(@item.add_release_nodes_and_start_releaseWF(tags)).to eq(nil) # Should run and return void

--- a/spec/dor/sdr_ingest_service_spec.rb
+++ b/spec/dor/sdr_ingest_service_spec.rb
@@ -64,7 +64,7 @@ describe Dor::SdrIngestService do
     before :each do
       druid = 'druid:dd116zh0343'
       @dor_item = double('dor_item')
-      expect(@dor_item).to receive(:initialize_workflow).with('sdrIngestWF', false)
+      expect(@dor_item).to receive(:create_workflow).with('sdrIngestWF', false)
       allow(@dor_item).to receive(:pid).and_return(druid)
       signature_catalog = Moab::SignatureCatalog.read_xml_file(@fixtures.join('sdr_repo/dd116zh0343/v0001/manifests'))
       @metadata_dir = @fixtures.join('workspace/dd/116/zh/0343/dd116zh0343/metadata')

--- a/spec/dor/versionable_spec.rb
+++ b/spec/dor/versionable_spec.rb
@@ -30,7 +30,7 @@ describe Dor::Versionable do
         expect(Dor::Config.workflow.client).to receive(:get_active_lifecycle).with('dor', dr, 'opened').and_return(nil)
         expect(Dor::Config.workflow.client).to receive(:get_active_lifecycle).with('dor', dr, 'submitted').and_return(nil)
         expect(Sdr::Client).to receive(:current_version).and_return(1)
-        expect(obj).to receive(:initialize_workflow).with('versioningWF')
+        expect(obj).to receive(:create_workflow).with('versioningWF')
         allow(obj).to receive(:new_object?).and_return(false)
         expect(vmd_ds).to receive(:save)
       end
@@ -128,7 +128,7 @@ describe Dor::Versionable do
 
       expect(Dor::Config.workflow.client).to receive(:close_version).with('dor', dr , true)
 
-      allow(obj).to receive(:initialize_workflow)
+      allow(obj).to receive(:create_workflow)
 
       vmd_ds.increment_version
       expect(vmd_ds).to receive(:save)


### PR DESCRIPTION
This PR changes the calls to `initialize_workflow`, which is deprecated, to `create_workflow`.

This gets rid of the deprecation warnings at runtime:

```
WARNING: initialize_workflow is deprecated, use create_workflow instead
```