### PR TITLE
match status of "404 Not Found"

### DIFF
--- a/lib/dor/models/releaseable.rb
+++ b/lib/dor/models/releaseable.rb
@@ -286,7 +286,7 @@ module Dor
         # We assume a 404 means the document has never been published before and thus has no purl
         Dor.logger.warn "[Attempt #{attempt_number}] GET #{url} -- #{exception.class}: #{exception.message}; #{total_delay} seconds elapsed."
         raise exception unless exception.is_a? OpenURI::HTTPError
-        return Nokogiri::HTML::Document.new if exception.message.strip == '404'    # strip is needed if the actual message is "404 "
+        return Nokogiri::HTML::Document.new if exception.io.status.first == '404' # ["404", "Not Found"] from OpenURI::Meta.status
       end
 
       with_retries(:max_retries => 3, :base_sleep_seconds => 3, :max_sleep_seconds => 5, :handler => handler) do |attempt|


### PR DESCRIPTION
This PR fixes a bug in the parsing of `OpenURI::HTTPError.message` when the value is `404 Not Found`.

I'm not sure why the tests were not failing before as releasable_spec tests for this case. They pass fine with the old code but in integration testing the code fails. Any insights welcome...