### PR TITLE
Stop indexing the workflow archive count

### DIFF
--- a/lib/dor/models/workflow_object.rb
+++ b/lib/dor/models/workflow_object.rb
@@ -43,12 +43,6 @@ module Dor
       definition.graph *args
     end
 
-    def to_solr(solr_doc = {}, *args)
-      super solr_doc, *args
-      solr_doc["#{definition.name}_archived_isi"] = Dor::Config.workflow.client.count_archived_for_workflow(definition.name)
-      solr_doc
-    end
-
     def generate_initial_workflow
       datastreams['workflowDefinition'].initial_workflow
     end

--- a/spec/dor/workflow_object_spec.rb
+++ b/spec/dor/workflow_object_spec.rb
@@ -22,10 +22,8 @@ describe Dor::WorkflowObject do
       @item.workflowDefinition.content = '<workflow-def id="accessionWF"/>'
     end
 
-    it 'indexes the number of archived objects for the workflow' do
-      expect(Dor::Config.workflow.client).to receive(:count_archived_for_workflow).and_return(5)
-      expect(@item.to_solr).to include 'accessionWF_archived_isi' => 5
+    it 'indexes the workflow name' do
+      expect(@item.to_solr).to include 'workflow_name_ssim' => 'accessionWF'
     end
   end
-
 end

--- a/spec/dor/workflow_object_spec.rb
+++ b/spec/dor/workflow_object_spec.rb
@@ -23,7 +23,7 @@ describe Dor::WorkflowObject do
     end
 
     it 'indexes the workflow name' do
-      expect(@item.to_solr).to include 'workflow_name_ssim' => 'accessionWF'
+      expect(@item.to_solr).to include 'workflow_name_ssim' => ['accessionWF']
     end
   end
 end


### PR DESCRIPTION
Calculating the count is an expensive operation, and the value is no longer
being presented downstream.