### PR TITLE
Have Dor.configure initialize the Dor::WorkflowService singleton

### DIFF
--- a/lib/dor/config.rb
+++ b/lib/dor/config.rb
@@ -25,6 +25,14 @@ module Dor
       ensure
         $-v = temp_v
       end
+
+      # Initialize and configure the global Dor::WorkflowService for clients that
+      # do not yet explicitly initialize their workflow connection and/or expect
+      # dor-services to handle that for them.
+      #
+      # TODO: Remove this in dor-services 6.x and/or dor-workflow-service 3.x
+      result.workflow.client
+
       result
     end
 
@@ -50,6 +58,10 @@ module Dor
         :url => Dor::Config.solr.url
       )
       ::RSolr::Ext.connect(opts)
+    end
+
+    def make_workflow_service(opts)
+
     end
 
     set_callback :initialize, :after do |config|

--- a/spec/dor/config_spec.rb
+++ b/spec/dor/config_spec.rb
@@ -31,6 +31,14 @@ describe Dor::Configuration do
   end
 
   it 'configures the Dor::WorkflowService when Dor::Config.configure is called' do
+    expect(Dor::WorkflowService).to receive(:configure).with('http://mynewurl.edu/workflow', kind_of(Hash))
+
+    @config.configure do
+      workflow.url 'http://mynewurl.edu/workflow'
+    end
+  end
+
+  it 'provides an accessor to the Dor::WorkflowService' do
     @config.configure do
       workflow.url 'http://mynewurl.edu/workflow'
     end


### PR DESCRIPTION
This fixes a regression for clients that assumed `dor-services` would automatically configure `Dor::WorkflowService`.