### PR TITLE
upgrade to dor-workflow-service 2.0.1

### DIFF
--- a/dor-services.gemspec
+++ b/dor-services.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'retries'
 
   # Stanford dependencies
-  s.add_dependency 'dor-workflow-service', '~> 2.0'
+  s.add_dependency 'dor-workflow-service', '~> 2.0', '>= 2.0.1'
   s.add_dependency 'druid-tools', '~> 0.4', '>= 0.4.1'
   s.add_dependency 'dor-rights-auth', '~> 1.0', '>= 1.0.2'
   s.add_dependency 'lyber-utils', '~> 0.1.2'


### PR DESCRIPTION
This PR _forces_ bundler to upgrade to dor-workflow-service 2.0.1