### PR TITLE
get_content_group_diff should handle the case when contentMetadata is missing

### DIFF
--- a/lib/dor/models/itemizable.rb
+++ b/lib/dor/models/itemizable.rb
@@ -23,20 +23,19 @@ module Dor
 
     # Retrieves file difference manifest for contentMetadata from SDR
     #
-    # @param [String] subset keyword for file attributes :shelve, :preserve, :publish. Default is :all.
+    # @param [Symbol] subset keyword for file attributes :shelve, :preserve, :publish. Default is :all.
     # @param [String] version
-    # @return [String] XML contents of cm_inv_diff manifest
+    # @return [Moab::FileInventoryDifference] XML contents of cm_inv_diff manifest
     def get_content_diff(subset = :all, version = nil)
       if Dor::Config.stacks.local_workspace_root.nil?
         raise Dor::ParameterError, 'Missing Dor::Config.stacks.local_workspace_root'
       end
 
-      current_content = datastreams['contentMetadata'].content
-      if current_content.nil?
+      if contentMetadata.nil?
         raise Dor::Exception, 'Missing contentMetadata datastream'
       end
 
-      Sdr::Client.get_content_diff(pid, current_content, subset, version)
+      Sdr::Client.get_content_diff(pid, contentMetadata.content, subset, version)
     end
   end
 end

--- a/lib/dor/services/technical_metadata_service.rb
+++ b/lib/dor/services/technical_metadata_service.rb
@@ -50,6 +50,8 @@ module Dor
     def self.get_content_group_diff(dor_item)
       inventory_diff = dor_item.get_content_diff('all')
       inventory_diff.group_difference('content')
+    rescue Dor::Exception # no contentMetadata
+      Moab::FileGroupDifference.new
     end
 
     # @param [FileGroupDifference] content_group_diff

--- a/lib/dor/utils/sdr_client.rb
+++ b/lib/dor/utils/sdr_client.rb
@@ -33,6 +33,7 @@ module Sdr
         Moab::SignatureCatalog.new(:digital_object_id => druid, :version_id => 0)
       end
 
+      # @return [Moab::FileInventoryDifference] the differences for the given content and subset
       def get_content_diff(druid, current_content, subset = :all, version = nil)
         unless %w(all shelve preserve publish).include?(subset.to_s)
           raise Dor::ParameterError, "Invalid subset value: #{subset}"

--- a/spec/dor/itemizable_spec.rb
+++ b/spec/dor/itemizable_spec.rb
@@ -11,17 +11,21 @@ describe Dor::Itemizable do
   after(:each)  { unstub_config }
 
   before :each do
-    @item = instantiate_fixture('druid:ab123cd4567', ItemizableItem)
-    @item.contentMetadata.content = '<contentMetadata/>'
+    @item = instantiate_fixture('druid:bb046xn0881', ItemizableItem)
   end
 
   it 'has a contentMetadata datastream' do
-    expect(@item.datastreams['contentMetadata']).to be_a(Dor::ContentMetadataDS)
+    expect(@item.contentMetadata).to be_a(Dor::ContentMetadataDS)
   end
 
   it 'will run get_content_diff' do
     expect(Sdr::Client).to receive(:get_content_diff).
-      with(@item.pid, @item.datastreams['contentMetadata'].content, :all, nil)
-    @item.get_content_diff
+      with(@item.pid, @item.contentMetadata.content, :all, nil)
+    expect { @item.get_content_diff }.not_to raise_error
+  end
+
+  it 'will run get_content_diff without contentMetadata' do
+    @item.datastreams.delete 'contentMetadata'
+    expect { @item.get_content_diff }.to raise_error(Dor::Exception)
   end
 end

--- a/spec/dor/technical_metadata_service_spec.rb
+++ b/spec/dor/technical_metadata_service_spec.rb
@@ -92,6 +92,13 @@ describe Dor::TechnicalMetadataService do
     end
   end
 
+  specify 'Dor::TechnicalMetadataService.get_content_group_diff(dor_item) without contentMetadata' do
+    dor_item = double(Dor::Item)
+    allow(dor_item).to receive(:get_content_diff).with('all').and_raise(Dor::Exception)
+    content_group_diff = Dor::TechnicalMetadataService.get_content_group_diff(dor_item)
+    expect(content_group_diff.difference_count).to be_zero
+  end
+
   specify 'Dor::TechnicalMetadataService.get_file_deltas(content_group_diff)' do
     @object_ids.each do |id|
       group_diff = @inventory_differences[id]


### PR DESCRIPTION
This PR fixes https://github.com/sul-dlss/argo/issues/651 by returning an empty `FileGroupDifference` when `contentMetadata` is missing.