### PR TITLE
Dor::Identifiable#get_related_obj_display_title fix, empty datastream tests

### DIFF
--- a/lib/dor/models/identifiable.rb
+++ b/lib/dor/models/identifiable.rb
@@ -209,15 +209,13 @@ module Dor
     end
 
     def get_related_obj_display_title(related_obj, default_title)
-      if related_obj
-        if related_obj.datastreams['DC'] && related_obj.datastreams['DC'].title
-          return related_obj.datastreams['DC'].title
-        else
-          return related_obj.label
-        end
+      # desc_md_ds_title will be nil if related_obj is nil
+      desc_md_ds_title = if related_obj
+        desc_md_ds = related_obj.datastreams['descMetadata']
+        desc_md_ds ? desc_md_ds.title_info.main_title.first : nil
       end
 
-      default_title
+      desc_md_ds_title.present? ? desc_md_ds_title : default_title
     end
 
     private

--- a/spec/datastreams/desc_metadata_spec.rb
+++ b/spec/datastreams/desc_metadata_spec.rb
@@ -61,6 +61,13 @@ describe Dor::DescMetadataDS do
           <subject><topic>Topic2: The Interesting Part!</topic></subject>
         </mods>
       EOF
+      @empty = Dor::DescMetadataDS.from_xml <<-EOF
+        <mods xmlns:xlink="http://www.w3.org/1999/xlink"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.3"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd">
+        </mods>
+      EOF
     end
 
     it 'should get correct values from OM terminology' do
@@ -88,6 +95,16 @@ describe Dor::DescMetadataDS do
       @partial.language.languageTerm = 'eng'
       @partial.abstract = 'Abstract contents.'
       expect(@partial.to_xml).to be_equivalent_to(@dsdoc.to_xml)
+    end
+    it 'should not throw an error when retrieving title_info if titleInfo is missing from the xml' do
+      expect(@empty.title_info.main_title).to eq([])
+    end
+  end
+
+  context 'Behavior of a freshly initialized Datastream' do
+    it 'should not throw an error when retrieving title_info if the datastream object has yet to have XML content set' do
+      desc_md_datastream = Dor::DescMetadataDS.new
+      expect(desc_md_datastream.title_info.main_title).to eq([""])
     end
   end
 end

--- a/spec/dor/identifiable_spec.rb
+++ b/spec/dor/identifiable_spec.rb
@@ -229,26 +229,50 @@ describe Dor::Identifiable do
   end
 
   describe 'get_related_obj_display_title' do
-    it 'should return the dc:title if it is available' do
+    it 'should return the descMetadata main title if it is available' do
       mock_apo_title = 'apo title'
       mock_apo_obj = double(Dor::AdminPolicyObject)
-      mock_dc_datastream = double(Dor::SimpleDublinCoreDs)
+      mock_desc_md_datastream = double(Dor::DescMetadataDS)
+      mock_title_info = double(OM::XML::DynamicNode)
 
-      allow(mock_dc_datastream).to receive(:title).and_return(mock_apo_title)
-      allow(mock_apo_obj).to receive(:datastreams).and_return({'DC' => mock_dc_datastream})
+      expect(mock_desc_md_datastream).to receive(:title_info).and_return(mock_title_info)
+      expect(mock_title_info).to receive(:main_title).and_return([mock_apo_title, ""])
+      expect(mock_apo_obj).to receive(:datastreams).and_return({'descMetadata' => mock_desc_md_datastream})
 
       mock_default_title = 'druid:zy098xw7654'
       expect(item.get_related_obj_display_title(mock_apo_obj, mock_default_title)).to eq(mock_apo_title)
     end
-    it 'should return the fedora label if the dc:title is not available' do
-      mock_apo_label = 'object label'
+    it 'should return the default if the first descMetadata main title entry is empty string' do
       mock_apo_obj = double(Dor::AdminPolicyObject)
+      mock_desc_md_datastream = double(Dor::DescMetadataDS)
+      mock_title_info = double(OM::XML::DynamicNode)
 
-      allow(mock_apo_obj).to receive(:label).and_return(mock_apo_label)
-      allow(mock_apo_obj).to receive(:datastreams).and_return({})
+      expect(mock_desc_md_datastream).to receive(:title_info).and_return(mock_title_info)
+      expect(mock_title_info).to receive(:main_title).and_return(["", ""])
+      expect(mock_apo_obj).to receive(:datastreams).and_return({'descMetadata' => mock_desc_md_datastream})
 
       mock_default_title = 'druid:zy098xw7654'
-      expect(item.get_related_obj_display_title(mock_apo_obj, mock_default_title)).to eq(mock_apo_label)
+      expect(item.get_related_obj_display_title(mock_apo_obj, mock_default_title)).to eq(mock_default_title)
+    end
+    it 'should return the default if the descMetadata main title array is empty' do
+      mock_apo_obj = double(Dor::AdminPolicyObject)
+      mock_desc_md_datastream = double(Dor::DescMetadataDS)
+      mock_title_info = double(OM::XML::DynamicNode)
+
+      expect(mock_desc_md_datastream).to receive(:title_info).and_return(mock_title_info)
+      expect(mock_title_info).to receive(:main_title).and_return([])
+      expect(mock_apo_obj).to receive(:datastreams).and_return({'descMetadata' => mock_desc_md_datastream})
+
+      mock_default_title = 'druid:zy098xw7654'
+      expect(item.get_related_obj_display_title(mock_apo_obj, mock_default_title)).to eq(mock_default_title)
+    end
+    it 'should return the default if the descMetadata datastream is not available' do
+      mock_apo_obj = double(Dor::AdminPolicyObject)
+
+      expect(mock_apo_obj).to receive(:datastreams).and_return({})
+
+      mock_default_title = 'druid:zy098xw7654'
+      expect(item.get_related_obj_display_title(mock_apo_obj, mock_default_title)).to eq(mock_default_title)
     end
     it 'should return the default if the related object is nil' do
       mock_apo_obj = nil


### PR DESCRIPTION
* identifiable.rb:  get_related_obj_display_title should use descMetadata title. 
 * identifiable_spec.rb:  update tests accordingly.
* desc_metadata_spec.rb:  add tests for empty datastream scenarios.  important to this fix because get_related_obj_display_title now relies on that behavior.

closes issue #196