### PR TITLE
Fix collection reference 404

### DIFF
--- a/lib/dor/models/describable.rb
+++ b/lib/dor/models/describable.rb
@@ -109,8 +109,13 @@ module Dor
     end
 
     def add_related_item_node_for_collection(doc, collection_druid)
+      begin
+        collection_obj = Dor::Item.find(collection_druid)
+      rescue ActiveFedora::ObjectNotFoundError
+        return nil
+      end
+
       title_node         = Nokogiri::XML::Node.new('title', doc)
-      collection_obj     = Dor::Item.find(collection_druid)
       title_node.content = Dor::Describable.get_collection_title(collection_obj)
 
       title_info_node = Nokogiri::XML::Node.new('titleInfo', doc)
@@ -147,7 +152,7 @@ module Dor
       return unless methods.include? :public_relationships
       collections = public_relationships.search('//rdf:RDF/rdf:Description/fedora:isMemberOfCollection',
                                        'fedora' => 'info:fedora/fedora-system:def/relations-external#',
-                                       'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#' )
+                                       'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#')
       return if collections.empty?
 
       remove_related_item_nodes_for_collections(doc)

--- a/lib/dor/models/describable.rb
+++ b/lib/dor/models/describable.rb
@@ -109,12 +109,12 @@ module Dor
     end
 
     def add_related_item_node_for_collection(doc, collection_druid)
-      collection_obj  = Dor::Item.find(collection_druid)
-      related_item_node = Nokogiri::XML::Node.new('relatedItem', doc)
-      related_item_node['type'] = 'host'
-      title_info_node = Nokogiri::XML::Node.new('titleInfo', doc)
-      title_node      = Nokogiri::XML::Node.new('title', doc)
+      title_node         = Nokogiri::XML::Node.new('title', doc)
+      collection_obj     = Dor::Item.find(collection_druid)
       title_node.content = Dor::Describable.get_collection_title(collection_obj)
+
+      title_info_node = Nokogiri::XML::Node.new('titleInfo', doc)
+      title_info_node.add_child(title_node)
 
       # e.g.:
       #   <location>
@@ -127,11 +127,15 @@ module Dor
 
       type_node = Nokogiri::XML::Node.new('typeOfResource', doc)
       type_node['collection'] = 'yes'
-      doc.root.add_child(related_item_node)
+
+      related_item_node = Nokogiri::XML::Node.new('relatedItem', doc)
+      related_item_node['type'] = 'host'
+
       related_item_node.add_child(title_info_node)
-      title_info_node.add_child(title_node)
       related_item_node.add_child(loc_node)
       related_item_node.add_child(type_node)
+
+      doc.root.add_child(related_item_node)
     end
 
     # Adds to desc metadata a relatedItem with information about the collection this object belongs to.


### PR DESCRIPTION
refactoring in small-ish increments, as seen in the commit history, then bug fixed in the last commit.

this assumes that we want to create a `relatedItem` node even if the reference is to a non-existent collection (in which case this change just stored the druid where it would store the collection name, a la the indexing behavior).  if we just want to not create a `relatedItem` node in these situations, that's easy enough also.  @LynnMcRae?