### PR TITLE
use dor-services-app SDR proxy for getting preserved file content

### DIFF
--- a/lib/dor/models/contentable.rb
+++ b/lib/dor/models/contentable.rb
@@ -62,12 +62,7 @@ module Dor
     end
 
     def get_preserved_file(file, version)
-      uri = URI(Config.content.sdr_server + "/sdr/objects/#{pid}/content/" + URI.encode(file) + "?version=#{version}")
-      req = Net::HTTP::Get.new(uri.request_uri)
-      req.basic_auth Config.content.sdr_user, Config.content.sdr_pass
-      Net::HTTP.start(uri.hostname, uri.port, :use_ssl => uri.scheme == 'https') {|http|
-        http.request(req)
-      }
+      Sdr::Client.get_preserved_file_content(pid, file, version)
     end
 
     def get_file(file)

--- a/lib/dor/utils/sdr_client.rb
+++ b/lib/dor/utils/sdr_client.rb
@@ -47,6 +47,10 @@ module Sdr
         Moab::FileInventoryDifference.parse(response)
       end
 
+      def get_preserved_file_content(druid, filename, version)
+        client["objects/#{druid}/content/#{URI.encode(filename)}?version=#{version}"].get
+      end
+
       def client
         if Dor::Config.sdr.url
           Dor::Config.sdr.rest_client

--- a/spec/dor/contentable_spec.rb
+++ b/spec/dor/contentable_spec.rb
@@ -126,6 +126,16 @@ describe Dor::Contentable do
       expect{ @item.replace_file(@file, 'abcdgw177fc7976_00_0001.tif')}.to raise_error(StandardError)
     end
   end
+  describe 'get_preserved_file' do
+    let(:filename) { 'old_file' }
+    let(:item_version) { 2 }
+    let(:preserved_file_content) { 'expected content' }
+    it 'should get the file content' do
+      expect(Sdr::Client).to receive(:get_preserved_file_content).with(@item.id, filename, item_version).and_return(preserved_file_content)
+      returned_content = @item.get_preserved_file(filename, item_version)
+      expect(returned_content).to eq(preserved_file_content)
+    end
+  end
   describe 'get_file' do
     it 'should fetch the file' do
       data_file = File.new(File.dirname(__FILE__) + '/../fixtures/ab123cd4567_descMetadata.xml')


### PR DESCRIPTION
* add Sdr::Client.get_preserved_file_content:  have Dor::Contentable#get_preserved_file use that, instead of directly using content.sdr_server with basic auth in Dor::Contentable#get_preserved_file.
* tests for Dor::Contentable#get_preserved_file and Sdr::Client.get_preserved_file_content.