### PR TITLE
workflow process status date solrization

### DIFF
--- a/lib/dor/workflow/document.rb
+++ b/lib/dor/workflow/document.rb
@@ -102,8 +102,8 @@ module Workflow
       processes.each do |process|
         next unless process.status.present?
         # add a record of the robot having operated on this item, so we can track robot activity
-        if process.date_time && process.status && (process.status == 'completed' || process.status == 'error')
-          solr_doc["wf_#{wf_name}_#{process.name}_dttsi"] = "#{process.date_time}Z"
+        if !process.date_time.blank? && process.status && (process.status == 'completed' || process.status == 'error')
+          solr_doc["wf_#{wf_name}_#{process.name}_dttsi"] = Time.parse(process.date_time).utc.iso8601
         end
         # index the error message without the druid so we hopefully get some overlap
         add_solr_value(solr_doc, 'wf_error', "#{wf_name}:#{process.name}:#{process.error_message}", wf_solr_type, wf_solr_attrs) if process.error_message


### PR DESCRIPTION
this fixes the way that dates for completed/errored workflow steps are added to the solr document, so that the dates are actually in the iso8601 format expected by solr (as opposed to an invalid format with a 'Z' appended to a date string that has a time zone offset).

also refines a bit of behavior to implement what was presumably intended (skipping non-existent dates).

tests added for both of those fixes.

deployed to stage, and was able to successfully index `druid:bb003xz2305`, which previously ran into the indexing error described in issue #214.

closes issue #214