### PR TITLE
add rights_descriptions_ssim to rights-related info in RightsMetadataDS#to_solr output, update tests

### DIFF
--- a/dor-services.gemspec
+++ b/dor-services.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   # Stanford dependencies
   s.add_dependency 'dor-workflow-service', '~> 2.0', '>= 2.0.1'
   s.add_dependency 'druid-tools', '~> 0.4', '>= 0.4.1'
-  s.add_dependency 'dor-rights-auth', '~> 1.0', '>= 1.0.2'
+  s.add_dependency 'dor-rights-auth', '~> 1.0', '>= 1.2.0'
   s.add_dependency 'lyber-utils', '~> 0.1.2'
   s.add_dependency 'moab-versioning', '~> 2.0'
   s.add_dependency 'modsulator', '~> 0.0.7'

--- a/lib/dor/datastreams/rights_metadata_ds.rb
+++ b/lib/dor/datastreams/rights_metadata_ds.rb
@@ -101,6 +101,57 @@ module Dor
       solr_doc['rights_primary_ssi'] = dra.index_elements[:primary]
       solr_doc['rights_errors_ssim'] = dra.index_elements[:errors] if dra.index_elements[:errors].size > 0
       solr_doc['rights_characteristics_ssim'] = dra.index_elements[:terms] if dra.index_elements[:terms].size > 0
+
+      solr_doc['rights_descriptions_ssim'] = [
+        dra.index_elements[:primary],
+
+        (dra.index_elements[:obj_locations_qualified] || []).map do |rights_info|
+          rule_suffix = rights_info[:rule] ? " (#{rights_info[:rule]})" : ''
+          "location: #{rights_info[:location]}#{rule_suffix}"
+        end,
+        (dra.index_elements[:file_locations_qualified] || []).map do |rights_info|
+          rule_suffix = rights_info[:rule] ? " (#{rights_info[:rule]})" : ''
+          "location: #{rights_info[:location]} (file)#{rule_suffix}"
+        end,
+
+        (dra.index_elements[:obj_agents_qualified] || []).map do |rights_info|
+          rule_suffix = rights_info[:rule] ? " (#{rights_info[:rule]})" : ''
+          "agent: #{rights_info[:agent]}#{rule_suffix}"
+        end,
+        (dra.index_elements[:file_agents_qualified] || []).map do |rights_info|
+          rule_suffix = rights_info[:rule] ? " (#{rights_info[:rule]})" : ''
+          "agent: #{rights_info[:agent]} (file)#{rule_suffix}"
+        end,
+
+        (dra.index_elements[:obj_groups_qualified] || []).map do |rights_info|
+          rule_suffix = rights_info[:rule] ? " (#{rights_info[:rule]})" : ''
+          "#{rights_info[:group]}#{rule_suffix}"
+        end,
+        (dra.index_elements[:file_groups_qualified] || []).map do |rights_info|
+          rule_suffix = rights_info[:rule] ? " (#{rights_info[:rule]})" : ''
+          "#{rights_info[:group]} (file)#{rule_suffix}"
+        end,
+
+        (dra.index_elements[:obj_world_qualified] || []).map do |rights_info|
+          rule_suffix = rights_info[:rule] ? " (#{rights_info[:rule]})" : ''
+          "world#{rule_suffix}"
+        end,
+        (dra.index_elements[:file_world_qualified] || []).map do |rights_info|
+          rule_suffix = rights_info[:rule] ? " (#{rights_info[:rule]})" : ''
+          "world (file)#{rule_suffix}"
+        end
+      ].flatten.uniq
+
+      # these two values are returned by index_elements[:primary], but are just a less granular version of
+      # what the other more specific fields return, so discard them
+      solr_doc['rights_descriptions_ssim'].reject! { |rights_desc| ['access_restricted', 'access_restricted_qualified'].include? rights_desc }
+      solr_doc['rights_descriptions_ssim'] << 'dark (file)' if dra.index_elements[:terms].include? 'none_read_file'
+
+      solr_doc['obj_rights_locations_ssim'] = dra.index_elements[:obj_locations] if !dra.index_elements[:obj_locations].blank?
+      solr_doc['file_rights_locations_ssim'] = dra.index_elements[:file_locations] if !dra.index_elements[:file_locations].blank?
+      solr_doc['obj_rights_agents_ssim'] = dra.index_elements[:obj_agents] if !dra.index_elements[:obj_agents].blank?
+      solr_doc['file_rights_agents_ssim'] = dra.index_elements[:file_agents] if !dra.index_elements[:file_agents].blank?
+
       # suppress empties
       %w(use_statement_ssim copyright_ssim).each do |key|
         solr_doc[key] = solr_doc[key].reject { |val| val.nil? || val == '' }.flatten unless solr_doc[key].nil?

--- a/spec/dor/rights_metadata_spec.rb
+++ b/spec/dor/rights_metadata_spec.rb
@@ -50,19 +50,73 @@ describe Dor::RightsMetadataDS do
     before :each do
       allow(OpenURI).to receive(:open_uri).with('https://purl-test.stanford.edu/bb046xn0881.xml').and_return('<xml/>')
     end
+
     it 'should have correct primary' do
       expect(Dor.logger).to receive(:warn).with(/Cannot index druid:bb046xn0881\.descMetadata/)
       doc = @item.to_solr
+
       expect(doc).to match a_hash_including(
-        'rights_primary_ssi'  => 'world_qualified',
-        'metadata_source_ssi' => 'DOR',
-        'title_tesim'         => ['Indianapolis 500'],
-        'rights_characteristics_ssim' => include(
-          'world_discover', 'has_group_rights', 'has_rule', 'group|stanford', 'world_read', 'world|no-download', 'profile:group1|world1'
+        'rights_primary_ssi'          => 'world_qualified',
+        'rights_descriptions_ssim'    => include(
+          'world_qualified', 'location: reading_room (no-download)', 'stanford', 'world (no-download)', 'dark (file)'
         ),
-        'use_license_machine_ssi' => 'by-nc'
+        'metadata_source_ssi'         => 'DOR',
+        'title_tesim'                 => ['Indianapolis 500'],
+        'rights_characteristics_ssim' => include(
+          'world_discover', 'has_group_rights', 'has_rule', 'group|stanford', 'location', 'location_with_rule',
+          'world_read', 'world|no-download', 'profile:group1|location1|world1', 'none_read_file'
+        ),
+        'use_license_machine_ssi'     => 'by-nc',
+        'obj_rights_locations_ssim'   => ['reading_room']
       )
-      expect(doc).not_to include('rights_errors_ssim')  # don't include empties
+      expect(doc).not_to include(
+        'rights_errors_ssim', 'file_rights_locations_ssim', 'obj_rights_agents_ssim', 'file_rights_agents_ssim'
+      )  # don't include empties
+    end
+
+    it 'should filter access_restricted from what gets aggregated into rights_descriptions_ssim' do
+      rights_md_ds = Dor::RightsMetadataDS.new
+      mock_dra_obj = double(Dor::RightsAuth)
+      expect(mock_dra_obj).to receive(:index_elements).with(no_args).at_least(:once).and_return(
+        :primary => 'access_restricted',
+        :errors  => [],
+        :terms   => [],
+        :obj_locations_qualified => [{:location => 'someplace', :rule => 'somerule'}],
+        :file_groups_qualified   => [{:group => 'somegroup', :rule => 'someotherrule'}]
+      )
+      expect(rights_md_ds).to receive(:dra_object).and_return(mock_dra_obj)
+
+      doc = rights_md_ds.to_solr
+      expect(doc).to match a_hash_including(
+        'rights_primary_ssi'       => 'access_restricted',
+        'rights_descriptions_ssim' => include('location: someplace (somerule)', 'somegroup (file) (someotherrule)'),
+      )
+      expect(doc).not_to match a_hash_including(
+        'rights_descriptions_ssim' => include('access_restricted')
+      )
+    end
+
+    it 'should include the simple fields that are present' do
+      rights_md_ds = Dor::RightsMetadataDS.new
+      mock_dra_obj = double(Dor::RightsAuth)
+      expect(mock_dra_obj).to receive(:index_elements).with(no_args).at_least(:once).and_return(
+        :primary => 'access_restricted',
+        :errors  => [],
+        :terms   => [],
+        :obj_locations  => ['location'],
+        :file_locations => ['file_specific_location'],
+        :obj_agents     => ['agent'],
+        :file_agents    => ['file_specific_agent']
+      )
+      expect(rights_md_ds).to receive(:dra_object).and_return(mock_dra_obj)
+
+      doc = rights_md_ds.to_solr
+      expect(doc).to match a_hash_including(
+        'obj_rights_locations_ssim'  => ['location'],
+        'file_rights_locations_ssim' => ['file_specific_location'],
+        'obj_rights_agents_ssim'     => ['agent'],
+        'file_rights_agents_ssim'    => ['file_specific_agent']
+      )
     end
   end
 end

--- a/spec/fixtures/item_druid_bb046xn0881.xml
+++ b/spec/fixtures/item_druid_bb046xn0881.xml
@@ -466,6 +466,13 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
     <machine>
       <group>stanford</group>
       <world rule="no-download"></world>
+      <location rule="no-download">reading_room</location>
+    </machine>
+  </access>
+  <access type="read">
+    <file>dark_file</file>
+    <machine>
+      <none/>
     </machine>
   </access>
   <use>
@@ -491,6 +498,13 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
     <machine>
       <group>stanford</group>
       <world rule="no-download"></world>
+      <location rule="no-download">reading_room</location>
+    </machine>
+  </access>
+  <access type="read">
+    <file>dark_file</file>
+    <machine>
+      <none/>
     </machine>
   </access>
   <use>


### PR DESCRIPTION
* add rights_descriptions_ssim to RightsMetadataDS#to_solr output.  rights_descriptions_ssim aggregates rights info into an _ssim field for indexing/faceting as human readable strings.
* rights_metadata_spec.rb: update tests for updated dor-rights-auth behavior and updated RightsMetadataDS#to_solr
* dor-services.gemspec: minimum dor-rights-auth version is now 1.2.0, need new fields from Dor::RightsAuth#index_elements

this is the dor-services part of the work described in sul-dlss/dor-rights-auth#17