### PR TITLE
remove extraneous displayType attribute from release tags

### DIFF
--- a/lib/dor/datastreams/identity_metadata_ds.rb
+++ b/lib/dor/datastreams/identity_metadata_ds.rb
@@ -40,7 +40,7 @@ class IdentityMetadataDS < ActiveFedora::OmDatastream
     node ? [node['source'], node.text].join(':') : nil
   end
 
-  # @param  [String, Nil] New value, or nil/empty string to delete sourceId node
+  # @param  [String, Nil] value, or nil/empty string to delete sourceId node
   # @return [String, Nil] The same value, as per Ruby convention for assignment operators
   # @note The actual values assigned will have leading/trailing whitespace stripped.
   def sourceId=(value)

--- a/lib/dor/models/identifiable.rb
+++ b/lib/dor/models/identifiable.rb
@@ -189,17 +189,6 @@ module Dor
         .any?
     end
 
-    # Removes all displayTypes from an item in preparation of adding a new display type
-    # @return Boolean True if displayTypes were removed, False if no displayTypes were removed
-    def remove_displayTypes
-      nodes = identityMetadata.ng_xml.search('//displayType')
-      # NOTE: .each after search is different than normal ruby enumerator:
-      # ~ ng_xml.search('//nonexistant_tag').each(&:foo) == 0
-      # ~ [].each(&:foo) == []
-      nodes.each(&:remove)
-      nodes.any?
-    end
-
     def update_tag(old_tag, new_tag)
       normtag = normalize_tag(old_tag)
       identityMetadata.ng_xml.search('//tag')

--- a/lib/dor/models/publishable.rb
+++ b/lib/dor/models/publishable.rb
@@ -33,7 +33,6 @@ module Dor
 
       im = datastreams['identityMetadata'].ng_xml.clone
       im.search('//release').each(&:remove) # remove any <release> tags from public xml which have full history
-      im.root.add_child(release_xml)
 
       pub.add_child(im.root) # add in modified identityMetadata datastream
       pub.add_child(datastreams['contentMetadata'].public_xml.root.clone)
@@ -81,7 +80,7 @@ module Dor
     # When publishing a PURL, we drop a `aa11bb2222` file into the `local_recent_changes` folder
     # to notify other applications watching the filesystem (i.e., purl-fetcher).
     # We also remove any .deletes entry that may have left over from a previous removal
-    # @param [String] `local_recent_changes` usually `/purl/recent_changes`
+    # @param [String] local_recent_changes usually `/purl/recent_changes`
     def publish_notify_on_success(local_recent_changes = Config.stacks.local_recent_changes)
       raise ArgumentError, "Missing local_recent_changes directory: #{local_recent_changes}" unless File.directory?(local_recent_changes)
       id = pid.gsub(/^druid:/, '')

--- a/lib/dor/models/releaseable.rb
+++ b/lib/dor/models/releaseable.rb
@@ -215,7 +215,7 @@ module Dor
 
     # Add a release node for the item
     # Will use the current time if timestamp not supplied. You can supply a timestap for correcting history, etc if desired
-    # Timestamp will be calculated by the function, if no displayType is passed in, it will default to file
+    # Timestamp will be calculated by the function
     #
     # @param release [Boolean] True or false for the release node
     # @param attrs [hash]  A hash of any attributes to be placed onto the tag
@@ -223,16 +223,13 @@ module Dor
     # @raise [ArgumentError] Raised if attributes are improperly supplied
     #
     # @example
-    #  item.add_tag(true,:release,{:tag=>'Fitch : Batch2',:what=>'self',:to=>'Searchworks',:who=>'petucket', :displayType='filmstrip'})
+    #  item.add_release_node(true,{:tag=>'Fitch : Batch2',:what=>'self',:to=>'Searchworks',:who=>'petucket'})
     def add_release_node(release, attrs = {})
+      allowed_release_attributes=[:tag,:what,:to,:who,:when] # any other release attributes sent in will be rejected and not stored
       identity_metadata_ds = identityMetadata
+      attrs.delete_if { |key, value| !allowed_release_attributes.include?(key) }
       attrs[:when] = Time.now.utc.iso8601 if attrs[:when].nil? # add the timestamp
-      attrs[:displayType] = 'file' if attrs[:displayType].nil? # default to file is no display type is passed
       valid_release_attributes(release, attrs)
-
-      # Remove the old displayType and then add the one for this tag
-      remove_displayTypes
-      identity_metadata_ds.add_value(:displayType, attrs[:displayType], {})
       identity_metadata_ds.add_value(:release, release.to_s, attrs)
     end
 
@@ -254,7 +251,6 @@ module Dor
       end
       raise ArgumentError, ':what must be self or collection' unless what_correct
       raise ArgumentError, 'the value set for this tag is not a boolean' if !!tag != tag # rubocop:disable Style/DoubleNegation
-      raise ArgumentError, ':displayType must be passed in as a String' unless attrs[:displayType].class == String
 
       validate_tag_format(attrs[:tag]) unless attrs[:tag].nil? # Will Raise exception if invalid tag
       true

--- a/lib/dor/models/releaseable.rb
+++ b/lib/dor/models/releaseable.rb
@@ -209,7 +209,6 @@ module Dor
       end
       raise ArgumentError, ':what must be self or collection' unless what_correct
       raise ArgumentError, 'the value set for this tag is not a boolean' if !!tag != tag # rubocop:disable Style/DoubleNegation
-      validate_tag_format(attrs[:tag]) unless attrs[:tag].nil? # Will Raise exception if invalid tag
       true
     end
 
@@ -223,9 +222,9 @@ module Dor
     # @raise [ArgumentError] Raised if attributes are improperly supplied
     #
     # @example
-    #  item.add_release_node(true,{:tag=>'Fitch : Batch2',:what=>'self',:to=>'Searchworks',:who=>'petucket'})
+    #  item.add_release_node(true,{:what=>'self',:to=>'Searchworks',:who=>'petucket'})
     def add_release_node(release, attrs = {})
-      allowed_release_attributes=[:tag,:what,:to,:who,:when] # any other release attributes sent in will be rejected and not stored
+      allowed_release_attributes=[:what,:to,:who,:when] # any other release attributes sent in will be rejected and not stored
       identity_metadata_ds = identityMetadata
       attrs.delete_if { |key, value| !allowed_release_attributes.include?(key) }
       attrs[:when] = Time.now.utc.iso8601 if attrs[:when].nil? # add the timestamp
@@ -244,15 +243,8 @@ module Dor
       [:who, :to, :what].each do |check_attr|
         raise ArgumentError, "#{check_attr} not supplied as a String" if attrs[check_attr].class != String
       end
-
-      what_correct = false
-      %w(self collection).each do |allowed_what_value|
-        what_correct = true if attrs[:what] == allowed_what_value
-      end
-      raise ArgumentError, ':what must be self or collection' unless what_correct
-      raise ArgumentError, 'the value set for this tag is not a boolean' if !!tag != tag # rubocop:disable Style/DoubleNegation
-
-      validate_tag_format(attrs[:tag]) unless attrs[:tag].nil? # Will Raise exception if invalid tag
+      raise ArgumentError, ':what must be self or collection' unless %w(self collection).include? attrs[:what]
+      raise ArgumentError, 'the value set for this tag is not a boolean' unless [true,false].include? tag
       true
     end
 

--- a/script/console
+++ b/script/console
@@ -31,5 +31,6 @@ silence_warnings do
   rescue LoadError
   end
 end
+WebMock.allow_net_connect! 
 
 IRB.start

--- a/spec/dor/identifiable_spec.rb
+++ b/spec/dor/identifiable_spec.rb
@@ -29,16 +29,6 @@ describe Dor::Identifiable do
     item
   end
 
-  describe 'Removing Display Types' do
-    it 'returns false when no displayTypes are present to be removed' do
-      expect(item.remove_displayTypes).to be_falsey
-    end
-    it 'returns true when displayTypes are present and removed' do
-      item.identityMetadata.add_value(:displayType, 'foo', {}) # Add in a displayType so we have one to remove
-      expect(item.remove_displayTypes).to be_truthy
-    end
-  end
-
   it 'should have an identityMetadata datastream' do
     expect(item.datastreams['identityMetadata']).to be_a(Dor::IdentityMetadataDS)
   end

--- a/spec/dor/publishable_spec.rb
+++ b/spec/dor/publishable_spec.rb
@@ -91,8 +91,9 @@ describe Dor::Publishable do
         expect(@item).to receive(:released_for).and_return({})
         @p_xml = Nokogiri::XML(@item.public_xml)
       end
-      it 'does not include a releaseData element' do
+      it 'does not include a releaseData element and any info in identityMetadata' do
         expect(@p_xml.at_xpath('/publicObject/releaseData')).to be_nil
+        expect(@p_xml.at_xpath('/publicObject/identityMetadata/release')).to be_nil
       end
     end
 
@@ -180,11 +181,12 @@ describe Dor::Publishable do
         expect(releases.map{ |r| r['to']}).to eq ['Searchworks', 'Some_special_place']
       end
 
-      it 'does include a releaseData element when there is content inside it' do
+      it 'include a releaseData element when there is content inside it, but does not include this release data in identityMetadata' do
         releaseData = '<releaseData><release>foo</release></releaseData>'
         allow(@item).to receive(:generate_release_xml).and_return(releaseData)
         p_xml = Nokogiri::XML(@item.public_xml)
         expect(p_xml.at_xpath('/publicObject/releaseData/release').inner_text).to eq 'foo'
+        expect(p_xml.at_xpath('/publicObject/identityMetadata/release')).to be_nil
       end
 
     end


### PR DESCRIPTION
 and do not allow other extraneous attributes from being added to release tags

also, do not include release tag information in public XML identity metadata

fixes #229 and fixes #226 (proxy tickets: sul-dlss/discovery-indexing#31 and sul-dlss/discovery-indexing#26)