### PR TITLE
Add the public mods descriptive metadata to the publicObject document

### DIFF
--- a/lib/dor/models/publishable.rb
+++ b/lib/dor/models/publishable.rb
@@ -41,6 +41,7 @@ module Dor
       rels = public_relationships.root
       pub.add_child(rels.clone) unless rels.nil? # TODO: Should never be nil in practice; working around an ActiveFedora quirk for testing
       pub.add_child(generate_dublin_core.root.clone)
+      pub.add_child(Nokogiri::XML(generate_public_desc_md).root.clone) if metadata_format == 'mods'
       pub.add_child(Nokogiri(generate_release_xml).root.clone) unless release_xml.children.size == 0 # If there are no release_tags, this prevents an empty <releaseData/> from being added
       # Note we cannot base this on if an individual object has release tags or not, because the collection may cause one to be generated for an item,
       # so we need to calculate it and then look at the final result.s

--- a/spec/dor/publishable_spec.rb
+++ b/spec/dor/publishable_spec.rb
@@ -125,6 +125,10 @@ describe Dor::Publishable do
       it 'rightsMetadata' do
         expect(@p_xml.at_xpath('/publicObject/rightsMetadata')).to be
       end
+      it 'generated mods' do
+        expect(@p_xml.at_xpath('/publicObject/mods:mods', 'mods' => 'http://www.loc.gov/mods/v3')).to be
+      end
+
       it 'generated dublin core' do
         expect(@p_xml.at_xpath('/publicObject/oai_dc:dc', 'oai_dc' => 'http://www.openarchives.org/OAI/2.0/oai_dc/')).to be
       end


### PR DESCRIPTION
This is expected to improve performance for applications and services that currently need to separately request the public xml and mods documents (exhibits, searchworks + revs indexing, purl itself, embed) with limited impact on applications that only need the public xml (stacks maybe the only consumer, although any performance degradation ought to be mitigated by better cache hit times).

We'll continuing publishing the stand-alone mods document, until such a time that everything has been republished (and the PURL code updated to use only the public xml document), or never (like the other stand-alone files we're producing that aren't consumed).
 