### PR TITLE
fix released_to_ssim

### DIFF
--- a/lib/dor/models/releaseable.rb
+++ b/lib/dor/models/releaseable.rb
@@ -323,8 +323,8 @@ module Dor
 
       # TODO: sort of worried about the performance impact in bulk reindex
       # situations, since released_for recurses all parent collections.  jmartin 2015-07-14
-      released_for(true).each { |key, val|
-        add_solr_value(solr_doc, 'released_to', key, :symbol, []) if val
+      released_for(true).each { |release_target, release_info|
+        add_solr_value(solr_doc, 'released_to', release_target, :symbol, []) if release_info['release']
       }
 
       # TODO: need to solrize whether item is released to purl?  does released_for return that?

--- a/spec/dor/releaseable_spec.rb
+++ b/spec/dor/releaseable_spec.rb
@@ -373,11 +373,13 @@ describe 'to_solr' do
 
   before :each do
     @rlsbl_item = instantiate_fixture('druid:ab123cd4567', ReleaseableItem)
-    @rlsbl_item.datastreams['identityMetadata'].content = read_fixture('identity_metadata_full.xml')
   end
 
   it 'should solrize release tags' do
-    allow(@rlsbl_item).to receive(:released_for).and_return('Project' => true, 'test_target' => true, 'test_nontarget' => false)
+    released_for_info = {
+      'Project' => {'release'=>true}, 'test_target' => {'release'=>true}, 'test_nontarget' => {'release'=>false}
+    }
+    allow(@rlsbl_item).to receive(:released_for).and_return(released_for_info)
     solr_doc = @rlsbl_item.to_solr
     released_to_field_name = Solrizer.solr_name('released_to', :symbol)
     expect(solr_doc).to match a_hash_including({released_to_field_name => %w(Project test_target)})


### PR DESCRIPTION
previously, `Releaseable#to_solr` contained a bug where it would show an object as being released to any target that appeared in the result of the `Releaseable#released_for` method.  this is because it was expecting the wrong structure for `released_for`'s return value (`to_solr` was assuming that it'd return a `true` or `false` for each target, but it actually returns a hash of the form `{'release' => true}` or `{'release' => false}`.

the first commit in the PR fixes the `to_solr` unit test so that it fails for the old buggy code (by mocking the `released_for` result correctly).  the second commit fixes the `to_solr` method itself so that it deals with the `released_for` result correctly.

closes #234 