### PR TITLE
Update to support active-fedora 6 - 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,26 @@ notifications:
   email: false
 
 rvm:
-  - 2.1.2
-  - 2.2.2
+  - 2.2.5
   - 2.3.1
+
+env:
+  - 'RAILS_VERSION="~> 4.2"'
+  - 'RAILS_VERSION="~> 5.0"'
+
+matrix:
+  include:
+    - env: 'RAILS_VERSION="~> 4.2"'
+      rvm: 2.1.2
+    - env:
+        - 'AF_VERSION="~> 6.0"'
+        - 'RAILS_VERSION="~> 4.2"'
+      rvm: 2.3.1
+    - env:
+        - 'AF_VERSION="~> 7.0"'
+        - 'RAILS_VERSION="~> 4.2"'
+      rvm: 2.3.1
+    - env:
+        - 'AF_VERSION="~> 8.0"'
+        - 'RAILS_VERSION="~> 4.2"'
+      rvm: 2.3.1

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,17 @@ end
 
 # Dependencies are defined in dor-services.gemspec
 gemspec
+
+gem 'activemodel', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
+gem 'active-fedora', ENV['AF_VERSION'] if ENV['AF_VERSION']
+
+
+# Due to a possible bundler bug, resolving the dependencies for linkeddata 1.99
+# either breaks or takes an incredibly long time. Pinning these dependencies
+# seem to make it work.
+gem 'linkeddata', '~> 1.99'
+gem 'rdf', '~> 1.99'
+gem 'ebnf', '1.0.0'
+gem 'rdf-reasoner', '~> 0.3.0'
+gem 'rdf-tabular', '~> 0.3.0'
+gem 'rdf-microdata', '2.0.2'

--- a/dor-services.gemspec
+++ b/dor-services.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
 
   # Runtime dependencies
-  s.add_dependency 'active-fedora', '~> 6.0'
+  s.add_dependency 'active-fedora', '>= 6.0', '< 9.a'
   s.add_dependency 'activesupport', '>= 3.2.18' # '~> 4.0' #
   s.add_dependency 'confstruct', '~> 0.2.7'
   s.add_dependency 'equivalent-xml', '~> 0.5', '>= 0.5.1' # 5.0 insufficient

--- a/lib/dor/datastreams/administrative_metadata_ds.rb
+++ b/lib/dor/datastreams/administrative_metadata_ds.rb
@@ -115,5 +115,10 @@ class AdministrativeMetadataDS < ActiveFedora::OmDatastream
     defaults.shelving.path.first
   end
 
+  # maintain AF < 8 indexing behavior
+  def prefix
+    ''
+  end
+
 end
 end

--- a/lib/dor/datastreams/content_metadata_ds.rb
+++ b/lib/dor/datastreams/content_metadata_ds.rb
@@ -53,7 +53,7 @@ module Dor
         fail ArgumentError, "Malformed externalFile data: #{externalFile.inspect}" if [src_resource_id, src_file_id, src_druid].map(&:blank?).any?
 
         # grab source item
-        src_item = Dor::Item.find(src_druid)
+        src_item = Dor.find(src_druid)
 
         # locate and extract the resourceId/fileId elements
         doc = src_item.datastreams['contentMetadata'].ng_xml
@@ -366,6 +366,11 @@ module Dor
         end
       end
       self.content = ng_xml.to_s
+    end
+
+    # maintain AF < 8 indexing behavior
+    def prefix
+      ''
     end
   end
 end

--- a/lib/dor/datastreams/default_object_rights_ds.rb
+++ b/lib/dor/datastreams/default_object_rights_ds.rb
@@ -138,5 +138,10 @@ module Dor
       template = Nokogiri::XSLT(File.read(File.expand_path('../human.xslt', __FILE__)))
       template.apply_to(xml_doc)
     end
+
+    # maintain AF < 8 indexing behavior
+    def prefix
+      ''
+    end
   end
 end

--- a/lib/dor/datastreams/desc_metadata_ds.rb
+++ b/lib/dor/datastreams/desc_metadata_ds.rb
@@ -43,5 +43,10 @@ module Dor
       end.doc
     end
 
+    # maintain AF < 8 indexing behavior
+    def prefix
+      ''
+    end
+
   end
 end

--- a/lib/dor/datastreams/embargo_metadata_ds.rb
+++ b/lib/dor/datastreams/embargo_metadata_ds.rb
@@ -28,7 +28,7 @@ class EmbargoMetadataDS < ActiveFedora::OmDatastream
   end
 
   def to_solr(solr_doc = {}, *args)
-    super
+    solr_doc = super
     #::Solrizer.insert_field(solr_doc, field_name, value, *index_types)
     rd1  = release_date
     rd20 = twenty_pct_release_date
@@ -105,6 +105,11 @@ class EmbargoMetadataDS < ActiveFedora::OmDatastream
 
     term_value_delete(:select => '//embargoMetadata/releaseAccess')
     ng_xml.root.add_child(new_doc.root.clone)
+  end
+
+  # maintain AF < 8 indexing behavior
+  def prefix
+    ''
   end
 
 end

--- a/lib/dor/datastreams/events_ds.rb
+++ b/lib/dor/datastreams/events_ds.rb
@@ -59,5 +59,10 @@ class EventsDS < ActiveFedora::OmDatastream
     end
   end
 
+  # maintain AF < 8 indexing behavior
+  def prefix
+    ''
+  end
+
 end
 end

--- a/lib/dor/datastreams/geo_metadata_ds.rb
+++ b/lib/dor/datastreams/geo_metadata_ds.rb
@@ -74,5 +74,10 @@ module Dor
         bb.xpath('gmd:southBoundLatitude/gco:Decimal', params).text.to_f
       )
     end
+
+    # maintain AF < 8 indexing behavior
+    def prefix
+      ''
+    end
   end
 end

--- a/lib/dor/datastreams/identity_metadata_ds.rb
+++ b/lib/dor/datastreams/identity_metadata_ds.rb
@@ -80,7 +80,7 @@ class IdentityMetadataDS < ActiveFedora::OmDatastream
   end
 
   def to_solr(solr_doc = {}, *args)
-    super(solr_doc, *args)
+    solr_doc = super(solr_doc, *args)
 
     if digital_object.respond_to?(:profile)
       digital_object.profile.each_pair do |property, value|
@@ -127,6 +127,11 @@ class IdentityMetadataDS < ActiveFedora::OmDatastream
     }
 
     solr_doc
+  end
+
+  # maintain AF < 8 indexing behavior
+  def prefix
+    ''
   end
 end # class
 end

--- a/lib/dor/datastreams/rights_metadata_ds.rb
+++ b/lib/dor/datastreams/rights_metadata_ds.rb
@@ -96,7 +96,7 @@ module Dor
     end
 
     def to_solr(solr_doc = {}, *args)
-      super(solr_doc, *args)
+      solr_doc = super(solr_doc, *args)
       dra = dra_object
       solr_doc['rights_primary_ssi'] = dra.index_elements[:primary]
       solr_doc['rights_errors_ssim'] = dra.index_elements[:errors] if dra.index_elements[:errors].size > 0
@@ -164,6 +164,11 @@ module Dor
     def use_license
       return creative_commons unless ['', nil].include?(creative_commons)
       return open_data_commons unless ['', nil].include?(open_data_commons)
+      ''
+    end
+
+    # maintain AF < 8 indexing behavior
+    def prefix
       ''
     end
 

--- a/lib/dor/datastreams/role_metadata_ds.rb
+++ b/lib/dor/datastreams/role_metadata_ds.rb
@@ -46,5 +46,10 @@ class RoleMetadataDS < ActiveFedora::OmDatastream
     solr_doc
   end
 
+  # maintain AF < 8 indexing behavior
+  def prefix
+    ''
+  end
+
 end
 end

--- a/lib/dor/datastreams/simple_dublin_core_ds.rb
+++ b/lib/dor/datastreams/simple_dublin_core_ds.rb
@@ -47,5 +47,10 @@ class SimpleDublinCoreDs < ActiveFedora::OmDatastream
     warn "ERROR in SimpleDublinCoreDs to_solr()! #{e}"
     solr_doc
   end
+
+  # maintain AF < 8 indexing behavior
+  def prefix
+    ''
+  end
 end
 end

--- a/lib/dor/datastreams/version_metadata_ds.rb
+++ b/lib/dor/datastreams/version_metadata_ds.rb
@@ -211,6 +211,11 @@ module Dor
       increment_version(opts[:description], opts[:significance])
     end
 
+    # maintain AF < 8 indexing behavior
+    def prefix
+      ''
+    end
+
     private
 
     # @return [Nokogiri::XML::Node] Node representing the current version
@@ -223,6 +228,5 @@ module Dor
       tags = find_by_terms(:version, :tag)
       tags.map {|t| VersionTag.parse(t.value)}.max
     end
-
   end
 end

--- a/lib/dor/datastreams/workflow_definition_ds.rb
+++ b/lib/dor/datastreams/workflow_definition_ds.rb
@@ -93,7 +93,7 @@ class WorkflowDefinitionDs < ActiveFedora::OmDatastream
   end
 
   def to_solr(solr_doc = {}, *args)
-    super(solr_doc, *args)
+    solr_doc = super(solr_doc, *args)
     add_solr_value(solr_doc, 'workflow_name', name, :symbol, [:symbol])
     processes.each do |p|
       add_solr_value(solr_doc, 'process', "#{p.name}|#{p.label}", :symbol, [:displayable])
@@ -103,6 +103,11 @@ class WorkflowDefinitionDs < ActiveFedora::OmDatastream
 
   def to_yaml
     YAML.dump(configuration)
+  end
+
+  # maintain AF < 8 indexing behavior
+  def prefix
+    ''
   end
 
 end

--- a/lib/dor/datastreams/workflow_ds.rb
+++ b/lib/dor/datastreams/workflow_ds.rb
@@ -71,8 +71,13 @@ module Dor
 
     def to_solr(solr_doc = {}, *args)
       # super solr_doc, *args
-      workflows.each { |wf| wf.to_solr(solr_doc, *args) }
+      workflows.each { |wf| solr_doc = wf.to_solr(solr_doc, *args) }
       solr_doc
+    end
+
+    # maintain AF < 8 indexing behavior
+    def prefix
+      ''
     end
   end
 end

--- a/lib/dor/models/admin_policy_object.rb
+++ b/lib/dor/models/admin_policy_object.rb
@@ -7,7 +7,7 @@ module Dor
     include Processable
     include Versionable
 
-    has_many :things, :property => :is_governed_by, :inbound => :true, :class_name => 'ActiveFedora::Base'
+    has_many :things, :property => :is_governed_by, :class_name => 'ActiveFedora::Base'
     has_object_type 'adminPolicy'
     has_metadata :name => 'administrativeMetadata', :type => Dor::AdministrativeMetadataDS, :label => 'Administrative Metadata'
     has_metadata :name => 'roleMetadata',           :type => Dor::RoleMetadataDS,           :label => 'Role Metadata'

--- a/lib/dor/models/collection.rb
+++ b/lib/dor/models/collection.rb
@@ -8,7 +8,7 @@ module Dor
     include Versionable
     include Releaseable
 
-    has_many :members, :property => :is_member_of_collection, :inbound => true, :class_name => 'ActiveFedora::Base'
+    has_many :members, :property => :is_member_of_collection, :class_name => 'ActiveFedora::Base'
     has_object_type 'collection'
   end
 end

--- a/lib/dor/models/contentable.rb
+++ b/lib/dor/models/contentable.rb
@@ -41,7 +41,7 @@ module Dor
 
     def replace_file(file, file_name)
       sftp = Net::SFTP.start(Config.content.content_server, Config.content.content_user, :auth_methods => ['publickey'])
-      item = Dor::Item.find(pid)
+      item = Dor.find(pid)
       druid_tools = DruidTools::Druid.new(pid, Config.content.content_base_dir)
       location = druid_tools.path(file_name)
       oldlocation = location.gsub('/' + pid.gsub('druid:', ''), '')
@@ -161,7 +161,7 @@ module Dor
       max_sequence = primary_cm.at_xpath('/contentMetadata/resource[last()]/@sequence').value.to_i
 
       source_obj_pids.each do |src_pid|
-        source_obj = Dor::Item.find src_pid
+        source_obj = Dor.find src_pid
         source_cm = source_obj.contentMetadata.ng_xml
 
         # Copy the resources from each source object

--- a/lib/dor/models/describable.rb
+++ b/lib/dor/models/describable.rb
@@ -110,7 +110,7 @@ module Dor
 
     def add_related_item_node_for_collection(doc, collection_druid)
       begin
-        collection_obj = Dor::Item.find(collection_druid)
+        collection_obj = Dor.find(collection_druid)
       rescue ActiveFedora::ObjectNotFoundError
         return nil
       end
@@ -172,7 +172,7 @@ module Dor
                                        'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#' ).each do |parent|
         # fetch the parent object to get title
         druid = parent['rdf:resource'].gsub(/^info:fedora\//, '')
-        parent_item = Dor::Item.find(druid)
+        parent_item = Dor.find(druid)
 
         # create the MODS relation
         relatedItem = doc.create_element 'relatedItem'
@@ -209,7 +209,7 @@ module Dor
     end
 
     def to_solr(solr_doc = {}, *args)
-      super solr_doc, *args
+      solr_doc = super solr_doc, *args
       mods_sources = {
         'sw_language_ssim'            => :sw_language_facet,
         'sw_language_tesim'           => :sw_language_facet,
@@ -246,7 +246,7 @@ module Dor
         creator_title = creator + title
         add_solr_value(solr_doc, 'creator_title', creator_title, :string, [:stored_sortable])
       rescue CrosswalkError => e
-        ActiveFedora.logger.warn "Cannot index #{pid}.descMetadata: #{e.message}"
+        Dor.logger.warn "Cannot index #{pid}.descMetadata: #{e.message}"
       end
 
       begin

--- a/lib/dor/models/editable.rb
+++ b/lib/dor/models/editable.rb
@@ -46,7 +46,7 @@ module Dor
     }.freeze
 
     def to_solr(solr_doc = {}, *args)
-      super(solr_doc, *args)
+      solr_doc = super(solr_doc, *args)
       add_solr_value(solr_doc, 'default_rights', default_rights, :string, [:symbol])
       add_solr_value(solr_doc, 'agreement', agreement, :string, [:symbol]) if agreement_object
       add_solr_value(solr_doc, 'default_use_license_machine', use_license, :string, [:stored_sortable])
@@ -328,7 +328,7 @@ module Dor
     end
     def agreement=(val)
       fail ArgumentError, 'agreement must have a valid druid' if val.blank?
-      self.agreement_object = Dor::Item.find val.to_s, :cast => true
+      self.agreement_object = Dor.find val.to_s, :cast => true
     end
   end
 end

--- a/lib/dor/models/governable.rb
+++ b/lib/dor/models/governable.rb
@@ -10,7 +10,7 @@ module Dor
     end
 
     def initiate_apo_workflow(name)
-      create_workflow(name, !self.new_object?)
+      create_workflow(name, !self.new_record?)
     end
 
     # Returns the default lane_id from the item's APO.  Will return 'default' if the item does not have

--- a/lib/dor/models/identifiable.rb
+++ b/lib/dor/models/identifiable.rb
@@ -58,7 +58,7 @@ module Dor
 
     def to_solr(solr_doc = {}, *args)
       assert_content_model
-      super(solr_doc, *args)
+      solr_doc = super(solr_doc, *args)
 
       solr_doc[Dor::INDEX_VERSION_FIELD] = Dor::VERSION
       solr_doc['indexed_at_dtsi'] = Time.now.utc.xmlschema

--- a/lib/dor/models/processable.rb
+++ b/lib/dor/models/processable.rb
@@ -155,7 +155,7 @@ module Dor
     end
 
     def to_solr(solr_doc = {}, *args)
-      super(solr_doc, *args)
+      solr_doc = super(solr_doc, *args)
       sortable_milestones = {}
       current_version = '1'
       begin

--- a/lib/dor/models/releaseable.rb
+++ b/lib/dor/models/releaseable.rb
@@ -79,7 +79,7 @@ module Dor
     def get_release_tags_for_item_and_all_governing_sets
       return_tags = release_nodes || {}
       collections.each do |collection|
-        return_tags = combine_two_release_tag_hashes(return_tags, Dor::Item.find(collection.id).get_release_tags_for_item_and_all_governing_sets) # recurvise so parents of parents are found
+        return_tags = combine_two_release_tag_hashes(return_tags, Dor.find(collection.id).get_release_tags_for_item_and_all_governing_sets) # recurvise so parents of parents are found
       end
       return_tags
     end
@@ -319,7 +319,7 @@ module Dor
     end
 
     def to_solr(solr_doc = {}, *args)
-      super(solr_doc, *args)
+      solr_doc = super(solr_doc, *args)
 
       # TODO: sort of worried about the performance impact in bulk reindex
       # situations, since released_for recurses all parent collections.  jmartin 2015-07-14

--- a/lib/dor/models/set.rb
+++ b/lib/dor/models/set.rb
@@ -7,7 +7,7 @@ module Dor
     include Publishable
     include Versionable
 
-    has_many :members, :property => :is_member_of_collection, :inbound => true, :class_name => 'ActiveFedora::Base'
+    has_many :members, :property => :is_member_of_collection, :class_name => 'ActiveFedora::Base'
     has_object_type 'set'
   end
 end

--- a/lib/dor/services/cleanup_reset_service.rb
+++ b/lib/dor/services/cleanup_reset_service.rb
@@ -14,7 +14,7 @@ module Dor
     end
 
     def self.get_druid_last_version(druid)
-      druid_obj = Dor::Item.find(druid)
+      druid_obj = Dor.find(druid)
       last_version = druid_obj.current_version.to_i
 
       # if the current version is still open, avoid this versioned directory

--- a/lib/dor/services/merge_service.rb
+++ b/lib/dor/services/merge_service.rb
@@ -11,9 +11,9 @@ module Dor
     end
 
     def initialize(primary_druid, secondary_pids, tag, logger = nil)
-      @primary = Dor::Item.find primary_druid
+      @primary = Dor.find primary_druid
       @secondary_pids = secondary_pids
-      @secondary_objs = secondary_pids.map {|pid|  Dor::Item.find pid }
+      @secondary_objs = secondary_pids.map {|pid|  Dor.find pid }
       if logger.nil?
         @logger = Logger.new(STDERR)
       else

--- a/lib/dor/services/registration_service.rb
+++ b/lib/dor/services/registration_service.rb
@@ -129,7 +129,7 @@ module Dor
         workflow_priority = params[:workflow_priority] ? params[:workflow_priority].to_i : 0
 
         Array(params[:seed_datastream]).each { |datastream_name| new_item.build_datastream(datastream_name) }
-        Array(params[:initiate_workflow]).each { |workflow_id| new_item.create_workflow(workflow_id, !new_item.new_object?, workflow_priority)}
+        Array(params[:initiate_workflow]).each { |workflow_id| new_item.create_workflow(workflow_id, !new_item.new_record?, workflow_priority)}
 
         new_item.assert_content_model
 

--- a/spec/dor/content_metadata_ds_spec.rb
+++ b/spec/dor/content_metadata_ds_spec.rb
@@ -26,7 +26,7 @@ describe Dor::ContentMetadataDS do
     </file>
     </resource>
     </contentMetadata>'
-    allow(Dor::Item).to receive(:find).and_return(@item)
+    allow(Dor).to receive(:find).and_return(@item)
     @file = {
       :name     => 'new_file.jp2',
       :shelve   => 'no',

--- a/spec/dor/content_metadata_merge_spec.rb
+++ b/spec/dor/content_metadata_merge_spec.rb
@@ -33,8 +33,8 @@ describe Dor::Contentable do
   before(:each) do
     allow(primary.inner_object).to receive(:repository).and_return(double('frepo').as_null_object)
     allow(src1.inner_object).to receive(:repository).and_return(double('frepo').as_null_object)
-    allow(Dor::Item).to receive(:find).with(src1_pid) { src1 }
-    allow(Dor::Item).to receive(:find).with(src2_pid) { src2 }
+    allow(Dor).to receive(:find).with(src1_pid) { src1 }
+    allow(Dor).to receive(:find).with(src2_pid) { src2 }
     primary.contentMetadata.content = <<-XML
     <?xml version="1.0"?>
     <contentMetadata objectId="ab123cd0001" type="map">

--- a/spec/dor/contentable_spec.rb
+++ b/spec/dor/contentable_spec.rb
@@ -49,7 +49,7 @@ describe Dor::Contentable do
     </file>
     </resource>
     </contentMetadata>'
-    allow(Dor::Item).to receive(:find).and_return(@item)
+    allow(Dor).to receive(:find).and_return(@item)
     file_path = File.dirname(__FILE__) + '/../fixtures/ab123cd4567_descMetadata.xml'
     # allow_any_instance_of(DruidTools::Druid).to receive(:path).and_return("#{file_path}/ab123cd4567/ab123cd4567_descMetadata.xml")
     @sftp = double(Net::SFTP)

--- a/spec/dor/describable_spec.rb
+++ b/spec/dor/describable_spec.rb
@@ -265,7 +265,7 @@ describe Dor::Describable do
       allow(@item).to receive(:public_relationships).and_return(relationships)
 
       @collection = instantiate_fixture('druid:ab123cd4567', Dor::Item)
-      allow(Dor::Item).to receive(:find) do |pid|
+      allow(Dor).to receive(:find) do |pid|
         pid == 'druid:ab123cd4567' ? @item : @collection
       end
     end
@@ -331,7 +331,7 @@ describe Dor::Describable do
 
       it 'does not add relatedItem and does not error out if the referenced collection does not exist' do
         non_existent_druid = 'druid:doesnotexist'
-        expect(Dor::Item).to receive(:find).with(non_existent_druid).and_raise(ActiveFedora::ObjectNotFoundError)
+        expect(Dor).to receive(:find).with(non_existent_druid).and_raise(ActiveFedora::ObjectNotFoundError)
         relationships_xml = <<-XML
         <?xml version="1.0"?>
         <rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -409,7 +409,7 @@ describe Dor::Describable do
       c_mods = Nokogiri::XML(read_fixture('ex1_mods.xml'))
       collection.datastreams['descMetadata'].content = c_mods.to_s
 
-      allow(Dor::Item).to receive(:find) do |pid|
+      allow(Dor).to receive(:find) do |pid|
         pid == 'druid:ab123cd4567' ? itm : collection
       end
     end

--- a/spec/dor/merge_service_spec.rb
+++ b/spec/dor/merge_service_spec.rb
@@ -72,8 +72,8 @@ describe Dor::MergeService do
       </contentMetadata>
       XML
 
-      allow(Dor::Item).to receive(:find).with(primary_pid) { primary }
-      allow(Dor::Item).to receive(:find).with(secondary_pid) { secondary }
+      allow(Dor).to receive(:find).with(primary_pid) { primary }
+      allow(Dor).to receive(:find).with(secondary_pid) { secondary }
       pri_druid_tree.mkdir
       create_tempfile pri_druid_tree.path, 'image_a.jp2'
     end

--- a/spec/dor/publishable_spec.rb
+++ b/spec/dor/publishable_spec.rb
@@ -363,8 +363,8 @@ describe Dor::Publishable do
         allow(@item).to receive(:add_collection_reference).and_call_original
         allow(@item).to receive(:add_constituent_relations).and_call_original
         # load up collection and constituent parent items from fixture data
-        expect(Dor::Item).to receive(:find).with('druid:xh235dd9059').and_return(instantiate_fixture('druid:xh235dd9059', DescribableItem))
-        expect(Dor::Item).to receive(:find).with('druid:hj097bm8879').and_return(instantiate_fixture('druid:hj097bm8879', DescribableItem))
+        expect(Dor).to receive(:find).with('druid:xh235dd9059').and_return(instantiate_fixture('druid:xh235dd9059', DescribableItem))
+        expect(Dor).to receive(:find).with('druid:hj097bm8879').and_return(instantiate_fixture('druid:hj097bm8879', DescribableItem))
 
         # test that we have 2 expansions
         doc = Nokogiri::XML(@item.generate_public_desc_md)
@@ -465,7 +465,7 @@ describe Dor::Publishable do
           child_item.label = child_item.datastreams[dsid].title
 
           # stub out retrieval for child item
-          allow(Dor::Item).to receive(:find).with(child_item.pid).and_return(child_item)
+          allow(Dor).to receive(:find).with(child_item.pid).and_return(child_item)
         end
 
         # generate publicObject XML and verify that the content metadata portion is correct and the correct thumb is present

--- a/spec/dor/rights_metadata_spec.rb
+++ b/spec/dor/rights_metadata_spec.rb
@@ -6,7 +6,7 @@ describe Dor::RightsMetadataDS do
 
   before(:each) do
     @item = instantiate_fixture('druid:bb046xn0881', Dor::Item)
-    allow(Dor::Item).to receive(:find).with(@item.pid).and_return(@item)
+    allow(Dor).to receive(:find).with(@item.pid).and_return(@item)
     allow(@item).to receive(:workflows).and_return(double)
     allow(Dor::Config.workflow.client).to receive(:get_milestones).and_return([])
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,7 +70,6 @@ end
 
 RSpec.configure do |config|
   config.include Dor::SpecHelpers
-  config.logger.level = Logger::WARN  # if you want INFO and lesser messages, tweak here
 end
 
 VCR.configure do |c|


### PR DESCRIPTION
The major changes in AF 7+ that affect dor-services are:

- `mediashelf-loggable` (which monkey-patches all `Object`s with a `#logger` instance) is no longer included.
- AF8 adds a datastream prefix to indexed fields by default; while this is probably a good idea, I've disabled this behavior for now
- `ActiveFedora::Base.find` is now aware of class hierarchy, so you can't call `Dor::Item.find` on e.g. a `Dor::Collection` and have it work right. 
- Upstream `#to_solr` no longer mutates its arguments.

Fortunately, the changes seem to be backwards compatible with AF 6.x. I don't know whether this should indicate a new major release or not.