### PR TITLE
add indexing benchmark metrics for load_instance and to_solr calls

### DIFF
--- a/spec/dor/indexing_service_spec.rb
+++ b/spec/dor/indexing_service_spec.rb
@@ -143,7 +143,7 @@ describe Dor::IndexingService do
     it 'should reindex the object via Dor::IndexingService.reindex_pid and log success' do
       expect(Dor).to receive(:load_instance).with(@mock_pid).and_return(@mock_obj)
       expect(Dor::IndexingService).to receive(:reindex_object).with(@mock_obj, {}).and_return(@mock_solr_doc)
-      expect(@mock_default_logger).to receive(:info).with("updated index for #{@mock_pid}")
+      expect(@mock_default_logger).to receive(:info).with(/successfully updated index for #{@mock_pid}.*metrics.*load_instance.*to_solr/)
       ret_val = Dor::IndexingService.reindex_pid @mock_pid
       expect(ret_val).to eq(@mock_solr_doc)
     end


### PR DESCRIPTION
This PR is connected to https://github.com/sul-dlss/dor_indexing_app/issues/49 and it implements some simple benchmark timings for the indexer's `Dor.load_instance` and `obj.to_solr` calls using the Ruby built-in `benchmark` API.

The log output looks like this in `indexing.log`:

```
I, [2016-11-08T11:48:51.413245 #8790]  INFO -- : successfully updated index for druid:aa111bb2222 (metrics: load_instance realtime 0.000022s total CPU 0.000000s; to_solr realtime 0.000039s total CPU 0.000000s)
```

Note that I did not move the location of the `logger.info` command but it logs *before* it actually adds the document to Solr via `RSolr.add`.