### PR TITLE
Refactor DOR models to use community-accepted practices around class inheritence

### DIFF
--- a/lib/dor-services.rb
+++ b/lib/dor-services.rb
@@ -21,7 +21,7 @@ module Dor
     # index is missing the objectType property.
     # @param [String] pid The object's PID
     def load_instance(pid)
-      Dor::Base.find pid, cast: true
+      Dor::Abstract.find pid, cast: true
     end
 
     # Get objectType information from solr and load the correct class the first time,
@@ -121,7 +121,6 @@ module Dor
     # ActiveFedora Classes
     autoload :Abstract,          'dor/models/abstract'
     autoload :Agreement,         'dor/models/agreement'
-    autoload :Base,              'dor/models/base'
     autoload :Item,              'dor/models/item'
     autoload :Set,               'dor/models/set'
     autoload :Collection,        'dor/models/collection'

--- a/lib/dor-services.rb
+++ b/lib/dor-services.rb
@@ -135,6 +135,7 @@ module Dor
     # ActiveFedora Classes
     autoload :Abstract,          'dor/models/abstract'
     autoload :Agreement,         'dor/models/agreement'
+    autoload :Base,              'dor/models/base'
     autoload :Item,              'dor/models/item'
     autoload :Set,               'dor/models/set'
     autoload :Collection,        'dor/models/collection'

--- a/lib/dor/models/abstract.rb
+++ b/lib/dor/models/abstract.rb
@@ -1,7 +1,11 @@
 module Dor
-  class Abstract < Dor::Base
+  class Abstract < ::ActiveFedora::Base
+    include Identifiable
+    include Eventable
+    include Governable
+    include Rightsable
     include Describable
-    include Processable
     include Versionable
+    include Processable
   end
 end

--- a/lib/dor/models/abstract.rb
+++ b/lib/dor/models/abstract.rb
@@ -1,5 +1,7 @@
 module Dor
-  class Abstract < ::ActiveFedora::Base
-    include Identifiable
+  class Abstract < Dor::Base
+    include Describable
+    include Processable
+    include Versionable
   end
 end

--- a/lib/dor/models/admin_policy_object.rb
+++ b/lib/dor/models/admin_policy_object.rb
@@ -1,11 +1,6 @@
 module Dor
-  class AdminPolicyObject < ::ActiveFedora::Base
-    include Identifiable
-    include Governable
+  class AdminPolicyObject < Dor::Abstract
     include Editable
-    include Describable
-    include Processable
-    include Versionable
 
     has_many :things, :property => :is_governed_by, :class_name => 'ActiveFedora::Base'
     has_object_type 'adminPolicy'

--- a/lib/dor/models/base.rb
+++ b/lib/dor/models/base.rb
@@ -1,8 +1,0 @@
-module Dor
-  class Base < ::ActiveFedora::Base
-    include Identifiable
-    include Eventable
-    include Governable
-    include Rightsable
-  end
-end

--- a/lib/dor/models/base.rb
+++ b/lib/dor/models/base.rb
@@ -1,0 +1,8 @@
+module Dor
+  class Base < ::ActiveFedora::Base
+    include Identifiable
+    include Eventable
+    include Governable
+    include Rightsable
+  end
+end

--- a/lib/dor/models/collection.rb
+++ b/lib/dor/models/collection.rb
@@ -1,14 +1,7 @@
 module Dor
-  class Collection < ::ActiveFedora::Base
-    include Identifiable
-    include Processable
-    include Governable
-    include Describable
-    include Publishable
-    include Versionable
+  class Collection < Dor::Set
     include Releaseable
 
-    has_many :members, :property => :is_member_of_collection, :class_name => 'ActiveFedora::Base'
     has_object_type 'collection'
   end
 end

--- a/lib/dor/models/embargoable.rb
+++ b/lib/dor/models/embargoable.rb
@@ -1,7 +1,6 @@
 module Dor
   module Embargoable
     extend ActiveSupport::Concern
-    include Dor::Publishable
 
     included do
       has_metadata :name => 'embargoMetadata', :type => Dor::EmbargoMetadataDS, :label => 'Embargo metadata'

--- a/lib/dor/models/governable.rb
+++ b/lib/dor/models/governable.rb
@@ -1,7 +1,6 @@
 module Dor
   module Governable
     extend ActiveSupport::Concern
-    include Rightsable
 
     included do
       belongs_to :admin_policy_object, :property => :is_governed_by, :class_name => 'Dor::AdminPolicyObject'

--- a/lib/dor/models/identifiable.rb
+++ b/lib/dor/models/identifiable.rb
@@ -2,7 +2,6 @@ module Dor
   module Identifiable
     extend ActiveSupport::Concern
     include SolrDocHelper
-    include Eventable
 
     included do
       has_metadata :name => 'DC', :type => SimpleDublinCoreDs, :label => 'Dublin Core Record for self object'

--- a/lib/dor/models/item.rb
+++ b/lib/dor/models/item.rb
@@ -1,11 +1,11 @@
 module Dor
-  class Item < ::ActiveFedora::Base
-    include Processable
+  class Item < Dor::Abstract
     include Shelvable
-    include Embargoable # implies Publishable implies Identifiable, Describable, Governable, Rightsable ...
+    include Embargoable
+    include Publishable
+    include Itemizable
     include Preservable
     include Assembleable
-    include Versionable
     include Contentable
     include Geoable
     include Releaseable

--- a/lib/dor/models/publishable.rb
+++ b/lib/dor/models/publishable.rb
@@ -4,11 +4,6 @@ require 'fileutils'
 module Dor
   module Publishable
     extend ActiveSupport::Concern
-    include Identifiable
-    include Governable
-    include Describable
-    include Itemizable
-    include Rightsable
 
     # Compute the thumbnail for this object following the rules at https://consul.stanford.edu/display/chimera/The+Rules+of+Thumb
     # @return [String] the computed thumb filename, with the druid prefix and a slash in front of it, e.g. oo000oo0001/filenamewith space.jp2

--- a/lib/dor/models/releaseable.rb
+++ b/lib/dor/models/releaseable.rb
@@ -4,7 +4,6 @@ require 'retries'
 module Dor
   module Releaseable
     extend ActiveSupport::Concern
-    include Itemizable
 
     # Add release tags to an item and initialize the item release workflow
     # Each tag should be of the form !{:tag => 'Fitch : Batch2', :what => 'self', :to => 'Searchworks', :who => 'petucket', :release => true}

--- a/lib/dor/models/set.rb
+++ b/lib/dor/models/set.rb
@@ -1,11 +1,6 @@
 module Dor
-  class Set < ::ActiveFedora::Base
-    include Identifiable
-    include Processable
-    include Governable
-    include Describable
+  class Set < Dor::Abstract
     include Publishable
-    include Versionable
 
     has_many :members, :property => :is_member_of_collection, :class_name => 'ActiveFedora::Base'
     has_object_type 'set'

--- a/lib/dor/models/shelvable.rb
+++ b/lib/dor/models/shelvable.rb
@@ -3,7 +3,6 @@ require 'moab/stanford'
 module Dor
   module Shelvable
     extend ActiveSupport::Concern
-    include Itemizable
 
     # Push file changes for shelve-able files into the stacks
     def shelve

--- a/lib/dor/models/versionable.rb
+++ b/lib/dor/models/versionable.rb
@@ -1,7 +1,6 @@
 module Dor
   module Versionable
     extend ActiveSupport::Concern
-    include Processable
 
     included do
       has_metadata :name => 'versionMetadata', :type => Dor::VersionMetadataDS, :label => 'Version Metadata', :autocreate => true

--- a/lib/dor/models/workflow_object.rb
+++ b/lib/dor/models/workflow_object.rb
@@ -1,7 +1,7 @@
 require 'dor/datastreams/workflow_definition_ds'
 
 module Dor
-  class WorkflowObject < Dor::Base
+  class WorkflowObject < Dor::Abstract
     @@xml_cache  = {}
     @@repo_cache = {}
 

--- a/lib/dor/models/workflow_object.rb
+++ b/lib/dor/models/workflow_object.rb
@@ -1,9 +1,7 @@
 require 'dor/datastreams/workflow_definition_ds'
 
 module Dor
-  class WorkflowObject < ::ActiveFedora::Base
-    include Identifiable
-    include Governable
+  class WorkflowObject < Dor::Base
     @@xml_cache  = {}
     @@repo_cache = {}
 

--- a/spec/dor/embargoable_spec.rb
+++ b/spec/dor/embargoable_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
 
 class EmbargoedItem < ActiveFedora::Base
+  include Dor::Rightsable
   include Dor::Embargoable
+  include Dor::Eventable
 end
 
 describe Dor::Embargoable do

--- a/spec/dor/publishable_spec.rb
+++ b/spec/dor/publishable_spec.rb
@@ -1,10 +1,15 @@
 require 'spec_helper'
 
 class PublishableItem < ActiveFedora::Base
+  include Dor::Identifiable
   include Dor::Contentable
   include Dor::Publishable
+  include Dor::Describable
   include Dor::Processable
   include Dor::Releaseable
+  include Dor::Rightsable
+  include Dor::Governable
+  include Dor::Itemizable
 end
 
 class DescribableItem < ActiveFedora::Base

--- a/spec/dor/registration_service_spec.rb
+++ b/spec/dor/registration_service_spec.rb
@@ -211,6 +211,8 @@ describe Dor::RegistrationService do
               <rdf:Description rdf:about="info:fedora/druid:ab123cd4567">
                 <hydra:isGovernedBy rdf:resource="info:fedora/druid:fg890hi1234"/>
                 <fedora-model:hasModel rdf:resource="info:fedora/afmodel:Dor_Item"/>
+                <fedora-model:hasModel rdf:resource='info:fedora/afmodel:Dor_Abstract' />
+                <fedora-model:hasModel rdf:resource='info:fedora/afmodel:Dor_Base' />
                 <fedora:isMemberOf rdf:resource="info:fedora/druid:zb871zd0767"/>
                 <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:zb871zd0767"/>
               </rdf:Description>
@@ -233,6 +235,8 @@ describe Dor::RegistrationService do
               <rdf:Description rdf:about="info:fedora/druid:ab123cd4567">
                 <hydra:isGovernedBy rdf:resource="info:fedora/druid:fg890hi1234"/>
                 <fedora-model:hasModel rdf:resource="info:fedora/afmodel:Dor_Item"/>
+                <fedora-model:hasModel rdf:resource='info:fedora/afmodel:Dor_Abstract' />
+                <fedora-model:hasModel rdf:resource='info:fedora/afmodel:Dor_Base' />
                 <fedora:isMemberOf rdf:resource="info:fedora/druid:something"/>
                 <fedora:isMemberOf rdf:resource="info:fedora/druid:zb871zd0767"/>
                 <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:something"/>

--- a/spec/dor/registration_service_spec.rb
+++ b/spec/dor/registration_service_spec.rb
@@ -212,7 +212,6 @@ describe Dor::RegistrationService do
                 <hydra:isGovernedBy rdf:resource="info:fedora/druid:fg890hi1234"/>
                 <fedora-model:hasModel rdf:resource="info:fedora/afmodel:Dor_Item"/>
                 <fedora-model:hasModel rdf:resource='info:fedora/afmodel:Dor_Abstract' />
-                <fedora-model:hasModel rdf:resource='info:fedora/afmodel:Dor_Base' />
                 <fedora:isMemberOf rdf:resource="info:fedora/druid:zb871zd0767"/>
                 <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:zb871zd0767"/>
               </rdf:Description>
@@ -236,7 +235,6 @@ describe Dor::RegistrationService do
                 <hydra:isGovernedBy rdf:resource="info:fedora/druid:fg890hi1234"/>
                 <fedora-model:hasModel rdf:resource="info:fedora/afmodel:Dor_Item"/>
                 <fedora-model:hasModel rdf:resource='info:fedora/afmodel:Dor_Abstract' />
-                <fedora-model:hasModel rdf:resource='info:fedora/afmodel:Dor_Base' />
                 <fedora:isMemberOf rdf:resource="info:fedora/druid:something"/>
                 <fedora:isMemberOf rdf:resource="info:fedora/druid:zb871zd0767"/>
                 <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:something"/>

--- a/spec/dor/shelvable_spec.rb
+++ b/spec/dor/shelvable_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 class ShelvableItem < ActiveFedora::Base
+  include Dor::Itemizable
   include Dor::Shelvable
 end
 

--- a/spec/dor/workflow_object_spec.rb
+++ b/spec/dor/workflow_object_spec.rb
@@ -23,6 +23,7 @@ describe Dor::WorkflowObject do
     end
 
     it 'indexes the workflow name' do
+      allow(@item).to receive(:milestones).and_return([])
       expect(@item.to_solr).to include 'workflow_name_ssim' => ['accessionWF']
     end
   end

--- a/spec/foxml_helper.rb
+++ b/spec/foxml_helper.rb
@@ -1,4 +1,4 @@
-def item_from_foxml(foxml, item_class = Dor::Base)
+def item_from_foxml(foxml, item_class = Dor::Abstract)
   foxml = Nokogiri::XML(foxml) unless foxml.is_a?(Nokogiri::XML::Node)
   xml_streams = foxml.xpath('//foxml:datastream')
   properties = Hash[foxml.xpath('//foxml:objectProperties/foxml:property').collect { |node|


### PR DESCRIPTION
All so we can use e.g. `Dor::Base.find` to retrieve any DOR model object, or `Dor::Set` to retrieve sets or collections..