### PR TITLE
Remove unused method_missing hack

### DIFF
--- a/lib/dor/models/identifiable.rb
+++ b/lib/dor/models/identifiable.rb
@@ -36,21 +36,6 @@ module Dor
       content_tag.size == 1 ? content_tag[0].split(':').last.strip : ''
     end
 
-    # Syntactic sugar for identifying applied DOR Concerns
-    # e.g., obj.is_identifiable? is the same as obj.is_a?(Dor::Identifiable)
-    def method_missing(sym, *args)
-      if sym.to_s =~ /^is_(.+)\?$/
-        begin
-          klass = Dor.const_get $1.capitalize.to_sym
-          return self.is_a?(klass)
-        rescue NameError
-          return false
-        end
-      else
-        super
-      end
-    end
-
     ## Module-level variables, shared between ALL mixin includers (and ALL *their* includers/extenders)!
     ## used for caching found values
     @@collection_hash = {}


### PR DESCRIPTION
As far as I can tell [1] , we have no consumers of this behavior, and it can make it confusing to understand stack traces.

[1] After looking through: argo assembly assembly-image assembly-objectfile assembly-utils common-accessioning dor-camel-routes dor-fetcher-service dor-services dor-services-app dor-utils dor-workflow-service dor_indexing_app item-release modsulator-app pre-assembly purl-fetcher revs-utils robot-controller wfs_rails workflow-service workflux