### PR TITLE
Refactor Preservable#build_provenanceMetadata_datastream

### DIFF
--- a/lib/dor/models/preservable.rb
+++ b/lib/dor/models/preservable.rb
@@ -11,11 +11,9 @@ module Dor
 
     def build_provenanceMetadata_datastream(workflow_id, event_text)
       workflow_provenance = create_workflow_provenance(workflow_id, event_text)
-      dsname = 'provenanceMetadata'
-      ds = datastreams[dsname]
-      ds.label = 'Provenance Metadata' unless datastreams.keys.include?(dsname)
+      ds = datastreams['provenanceMetadata']
+      ds.label ||= 'Provenance Metadata'
       ds.ng_xml = workflow_provenance
-      ds.content = ds.ng_xml.to_s
       ds.save
     end
 


### PR DESCRIPTION
The `content=` is unnecessary; see  https://github.com/projecthydra/active_fedora/blob/8.x-stable/lib/active_fedora/datastreams/nokogiri_datastreams.rb#L50