### PR TITLE
Remove unused descMetadata setters

### DIFF
--- a/lib/dor/models/describable.rb
+++ b/lib/dor/models/describable.rb
@@ -267,31 +267,6 @@ module Dor
       solr_doc
     end
 
-    def update_title(new_title)
-      raise 'Descriptive metadata has no title to update!' unless update_simple_field('mods:mods/mods:titleInfo/mods:title', new_title)
-    end
-
-    def add_identifier(type, value)
-      ds_xml = descMetadata.ng_xml
-      ds_xml.search('//mods:mods', 'mods' => 'http://www.loc.gov/mods/v3').each do |node|
-        new_node = Nokogiri::XML::Node.new('identifier', ds_xml) # this ends up being mods:identifier without having to specify the namespace
-        new_node['type'] = type
-        new_node.content = value
-        node.add_child(new_node)
-      end
-    end
-
-    def delete_identifier(type, value = nil)
-      ds_xml = descMetadata.ng_xml
-      ds_xml.search('//mods:identifier', 'mods' => 'http://www.loc.gov/mods/v3').each do |node|
-        if node.content == value || value.nil?
-          node.remove
-          return true
-        end
-      end
-      false
-    end
-
     # @param [Boolean] force Overwrite existing XML
     # @return [String] descMetadata.content XML
     def set_desc_metadata_using_label(force = false)
@@ -324,15 +299,6 @@ module Dor
     end
 
     private
-
-    # generic updater useful for updating things like title or subtitle which can only have a single occurance and must be present
-    def update_simple_field(field, new_val)
-      descMetadata.ng_xml.search('//' + field, 'mods' => 'http://www.loc.gov/mods/v3').each do |node|
-        node.content = new_val
-        return true
-      end
-      false
-    end
 
     # Builds case-insensitive xpath translate function call that will match the attribute to a value
     def ci_compare(attribute, value)

--- a/spec/dor/describable_spec.rb
+++ b/spec/dor/describable_spec.rb
@@ -515,50 +515,6 @@ describe Dor::Describable do
     expect {b.generate_dublin_core}.to raise_error(Dor::Describable::CrosswalkError)
   end
 
-  describe 'update_title' do
-    it 'should update the title' do
-      found = false
-      @obj.update_title('new title')
-      @obj.descMetadata.ng_xml.search('//mods:mods/mods:titleInfo/mods:title', 'mods' => 'http://www.loc.gov/mods/v3').each do |node|
-        expect(node.content).to eq('new title')
-        found = true
-      end
-      expect(found).to be_truthy
-    end
-    it 'should raise an exception if the mods lacks a title' do
-      @obj.update_title('new title')
-      @obj.descMetadata.ng_xml.search('//mods:mods/mods:titleInfo/mods:title', 'mods' => 'http://www.loc.gov/mods/v3').each do |node|
-        node.remove
-      end
-      expect {@obj.update_title('druid:oo201oo0001', 'new title')}.to raise_error(StandardError)
-    end
-  end
-  describe 'add_identifier' do
-    it 'should add an identifier' do
-      @obj.add_identifier('type', 'new attribute')
-      res = @obj.descMetadata.ng_xml.search('//mods:identifier[@type="type"]', 'mods' => 'http://www.loc.gov/mods/v3')
-      expect(res.length).to be > 0
-      res.each do |node|
-        expect(node.content).to eq('new attribute')
-      end
-    end
-  end
-  describe 'delete_identifier' do
-    it 'should delete an identifier' do
-      @obj.add_identifier('type', 'new attribute')
-      res = @obj.descMetadata.ng_xml.search('//mods:identifier[@type="type"]', 'mods' => 'http://www.loc.gov/mods/v3')
-      expect(res.length).to be > 0
-      res.each do |node|
-        expect(node.content).to eq('new attribute')
-      end
-      expect(@obj.delete_identifier('type', 'new attribute')).to be_truthy
-      res = @obj.descMetadata.ng_xml.search('//mods:identifier[@type="type"]', 'mods' => 'http://www.loc.gov/mods/v3')
-      expect(res.length).to eq 0
-    end
-    it 'should return false if there was nothing to delete' do
-      expect(@obj.delete_identifier('type', 'new attribute')).to be_falsey
-    end
-  end
   describe 'set_desc_metadata_using_label' do
     it 'should create basic mods using the object label' do
       allow(@obj.datastreams['descMetadata']).to receive(:content).and_return ''


### PR DESCRIPTION
I don't see where these setters are being used any more. All the downstream code I've found uses e.g. `Editable#mods_title=` instead.