### PR TITLE
[WIP] Use ActiveFedora to manage constituent object relationships

### DIFF
--- a/lib/dor/models/contentable.rb
+++ b/lib/dor/models/contentable.rb
@@ -2,6 +2,10 @@ module Dor
   module Contentable
     extend ActiveSupport::Concern
 
+    included do
+      has_and_belongs_to_many :constituent_objects, property: :is_constituent_of, class_name: 'ActiveFedora::Base'
+    end
+
     # add a file to a resource, not to be confused with add a resource to an object
     def add_file(file, resource, file_name, mime_type = nil, publish = 'no', shelve = 'no', preserve = 'no')
       xml = datastreams['contentMetadata'].ng_xml
@@ -227,7 +231,7 @@ module Dor
     # @param [String] druid the parent druid of the constituent relationship
     #   e.g.: <fedora:isConstituentOf rdf:resource="info:fedora/druid:hj097bm8879" />
     def add_constituent(druid)
-      add_relationship :is_constituent_of, ActiveFedora::Base.find(druid)
+      constituent_objects << ActiveFedora::Base.find(druid)
     end
   end
 end

--- a/lib/dor/models/describable.rb
+++ b/lib/dor/models/describable.rb
@@ -163,13 +163,7 @@ module Dor
     # @param [Nokogiri::XML] doc public MODS XML being built
     # @return [Void]
     def add_constituent_relations(doc)
-      public_relationships.search('//rdf:RDF/rdf:Description/fedora:isConstituentOf',
-                                       'fedora' => 'info:fedora/fedora-system:def/relations-external#',
-                                       'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#' ).each do |parent|
-        # fetch the parent object to get title
-        druid = parent['rdf:resource'].gsub(/^info:fedora\//, '')
-        parent_item = Dor.find(druid)
-
+      constituent_objects.each do |parent_item|
         # create the MODS relation
         relatedItem = doc.create_element 'relatedItem'
         relatedItem['type'] = 'host'

--- a/spec/dor/contentable_spec.rb
+++ b/spec/dor/contentable_spec.rb
@@ -5,7 +5,7 @@ class ContentableItem < ActiveFedora::Base
   include Dor::Contentable
 end
 
-class SpecNode
+class SpecNode < ActiveFedora::Base
   include ActiveFedora::SemanticNode
 
   attr_accessor :pid
@@ -15,6 +15,10 @@ class SpecNode
 
   def internal_uri
     'info:fedora/' + pid.to_s
+  end
+  
+  def new_record?
+    false
   end
 end
 


### PR DESCRIPTION
Fixes #206

- [ ] Update ActiveFedora to avoid unnecessary calls to Solr, or
- [ ] Stub `ActiveFedora::SolrService` calls for retrieving `has_and_belongs_to_many` relations