### PR TITLE
Change default local purl mount config to /purl/document_cache

### DIFF
--- a/config/config_defaults.yml
+++ b/config/config_defaults.yml
@@ -47,7 +47,7 @@
   :document_cache_host:
   :document_cache_user:
   :local_stacks_root: /stacks
-  :local_document_cache_root: /purl
+  :local_document_cache_root: /purl/document_cache
   :url:
   :iiif_profile:
 :suri:


### PR DESCRIPTION
Fixes #222?