### PR TITLE
add reindex_pid_remotely to execute reindex logic via remote call to dor-indexing-app

### DIFF
--- a/config/config_defaults.yml
+++ b/config/config_defaults.yml
@@ -63,6 +63,8 @@
   :shift_age: weekly
 :dor_services:
   :url:
+:dor_indexing_app:
+  :url:
 :indexing_svc:
   :log: 'log/indexing_svc.log'
   :log_date_format_str: '%Y-%m-%d %H:%M:%S.%L'

--- a/spec/dor_config.rb
+++ b/spec/dor_config.rb
@@ -26,4 +26,5 @@ Dor.configure do
   workflow.url     'http://example.edu/workflow/'
   sdr.url          'http://example.edu/sdr'
   dor_services.url 'https://example.edu/dor'
+  dor_indexing_app.url 'https://example.edu/dor'
 end


### PR DESCRIPTION
This PR is connected to https://github.com/sul-dlss/dor_indexing_app/issues/105. It adds a new method `Dor:: IndexingService.reindex_pid_remotely` that does a POST to the dor-indexing-app instead of actually doing the reindex itself.

I wasn't sure whether this code should go directly into Argo, or in dor-services. I went for dor-services as it seems generally useful in here.

Note that this PR requires a configuration change to `config.yml` -- namely the `Config.dor_indexing_app.url` setting.