### PR TITLE
Stop generating dublin core fields for indexing

### DIFF
--- a/lib/dor/models/concerns/describable.rb
+++ b/lib/dor/models/concerns/describable.rb
@@ -201,34 +201,12 @@ module Dor
     def to_solr(solr_doc = {}, *args)
       solr_doc = super solr_doc, *args
       add_metadata_format_to_solr_doc(solr_doc)
-      add_dc_to_solr_doc(solr_doc)
       add_mods_to_solr_doc(solr_doc)
     end
 
     def add_metadata_format_to_solr_doc(solr_doc)
       solr_doc['metadata_format_ssim'] ||= []
       solr_doc['metadata_format_ssim'] += ['mods']
-    end
-
-    def add_dc_to_solr_doc(solr_doc)
-      dc_doc = generate_dublin_core(include_collection_as_related_item: false)
-      # we excluding the generated collection relation here; we instead get the collection
-      # title from Dor::Identifiable.
-      dc_doc.xpath('/oai_dc:dc/*', oai_dc: XMLNS_OAI_DC).each do |node|
-        add_solr_value(solr_doc, "public_dc_#{node.name}", node.text, :string, [:stored_searchable])
-      end
-      creator = ''
-      dc_doc.xpath('//dc:creator', dc: XMLNS_DC).each do |node|
-        creator = node.text
-      end
-      title = ''
-      dc_doc.xpath('//dc:title', dc: XMLNS_DC).each do |node|
-        title = node.text
-      end
-      creator_title = creator + title
-      add_solr_value(solr_doc, 'creator_title', creator_title, :string, [:stored_sortable])
-    rescue CrosswalkError => e
-      Dor.logger.warn "Cannot index #{pid}.descMetadata: #{e.message}"
     end
 
     def add_mods_to_solr_doc(solr_doc)

--- a/spec/datastreams/rights_metadata_spec.rb
+++ b/spec/datastreams/rights_metadata_spec.rb
@@ -336,7 +336,6 @@ describe Dor::RightsMetadataDS do
     end
 
     it 'should have correct primary' do
-      expect(Dor.logger).to receive(:warn).with(/Cannot index druid:bb046xn0881\.descMetadata/)
       doc = @item.to_solr
 
       expect(doc).to match a_hash_including(

--- a/spec/models/concerns/describable_spec.rb
+++ b/spec/models/concerns/describable_spec.rb
@@ -22,21 +22,6 @@ describe Dor::Describable do
     @obj.datastreams['descMetadata'].content = read_fixture('ex1_mods.xml')
   end
 
-  it 'should add a creator_title field' do
-    expected_dc = read_fixture('ex1_dc.xml')
-    found = 0
-    allow(@simple).to receive(:generate_dublin_core).and_return(Nokogiri::XML(expected_dc))
-    # this is hacky but effective
-    allow(@simple).to receive(:add_solr_value) do |doc, field, value, otherstuff|
-      if field == 'creator_title'
-        expect(value).to eq('George, Henry, 1839-1897The complete works of Henry George')
-        found = 1
-      end
-    end
-    @simple.to_solr({})
-    expect(found).to eq 1
-  end
-
   it 'should have a descMetadata datastream' do
     expect(@item.datastreams['descMetadata']).to be_a(Dor::DescMetadataDS)
   end

--- a/spec/models/concerns/processable_spec.rb
+++ b/spec/models/concerns/processable_spec.rb
@@ -154,8 +154,6 @@ describe Dor::Processable do
     end
 
     it 'should include the semicolon delimited version, an earliest published date and a status' do
-      #     allow(@item.descMetadata).to receive(:to_solr).and_return({})
-      expect(Dor.logger).to receive(:warn)
       solr_doc = @item.to_solr
       # lifecycle_display should have the semicolon delimited version
       expect(solr_doc['lifecycle_ssim']).to include('published:2012-01-27T05:06:54Z;2')
@@ -189,7 +187,6 @@ describe Dor::Processable do
       expect(solr_doc['modified_latest_dttsi']).to match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ$/)
     end
     it 'should create a version field for each version, including the version number, tag and description' do
-      expect(Dor.logger).to receive(:warn).with(/Cannot index druid:ab123cd4567\.descMetadata.*Dor::Item#generate_dublin_core produced incorrect xml/)
       solr_doc = @item.to_solr
       expect(solr_doc['versions_ssm'].length).to be > 1
       expect(solr_doc['versions_ssm']).to include('4;2.2.0;Another typo')
@@ -211,7 +208,6 @@ describe Dor::Processable do
       </versionMetadata>
       '
       allow(@item).to receive(:versionMetadata).and_return(Dor::VersionMetadataDS.from_xml(dsxml))
-      expect(Dor.logger).to receive(:warn).with(/Cannot index druid:ab123cd4567\.descMetadata.*Dor::Item#generate_dublin_core produced incorrect xml/)
       solr_doc = @item.to_solr
       expect(solr_doc['versions_ssm']).to include('4;2.2.0;')
     end


### PR DESCRIPTION
Now that Argo 3.10 is deployed to all environments, we should be able to stop indexing into these fields.