### PR TITLE
Remove unused geoable methods

### DIFF
--- a/lib/dor/models/concerns/geoable.rb
+++ b/lib/dor/models/concerns/geoable.rb
@@ -2,30 +2,11 @@ module Dor
   module Geoable
     extend ActiveSupport::Concern
 
-    class CrosswalkError < Exception; end
-
     included do
       has_metadata  :name => 'geoMetadata',
                     :type => Dor::GeoMetadataDS,
                     :label => 'Geographic Information Metadata in ISO 19139',
                     :control_group => 'M'
-    end
-
-    # @return [String, nil] XML
-    def fetch_geoMetadata_datastream
-      candidates = datastreams['identityMetadata'].otherId.collect { |oid| oid.to_s }
-      metadata_id = Dor::MetadataService.resolvable(candidates).first
-      return nil if metadata_id.nil?
-      Dor::MetadataService.fetch(metadata_id.to_s)
-    end
-
-    def build_geoMetadata_datastream(ds)
-      content = fetch_geoMetadata_datastream
-      return nil if content.nil?
-      ds.dsLabel = label
-      ds.ng_xml = Nokogiri::XML(content)
-      ds.ng_xml.normalize_text!
-      ds.content = ds.ng_xml.to_xml
     end
   end
 end

--- a/spec/models/concerns/geoable_spec.rb
+++ b/spec/models/concerns/geoable_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 class GeoableItem < ActiveFedora::Base
   include Dor::Identifiable
-  include Dor::Describable
   include Dor::Geoable
 end
 
@@ -14,18 +13,8 @@ describe Dor::Geoable do
     @item = GeoableItem.new
   end
 
-  it 'should have a descMetadata datastream' do
-    expect(@item.datastreams['descMetadata']).to be_a(Dor::DescMetadataDS)
-  end
-
   it 'should have a geoMetadata datastream' do
     expect(@item.datastreams['geoMetadata']).to be_a(Dor::GeoMetadataDS)
-  end
-
-  it 'expected methods' do
-    %w(build_geoMetadata_datastream fetch_geoMetadata_datastream).each do |k|
-      expect(@item.public_methods).to include(k.to_sym)
-    end
   end
 
   it 'expected constants' do


### PR DESCRIPTION
@drh-stanford I don't think these methods are being used and were just copied from `Dor::Describable`. As far as I can tell, `Dor::MetadataService` only retrieves MODS from Symphony, which I assume doesn't make sense to put into the `geoMetadata` datastream.