### PR TITLE
[WIP] consider skipped as a completed state

### DIFF
--- a/lib/dor/workflow/process.rb
+++ b/lib/dor/workflow/process.rb
@@ -43,7 +43,7 @@ module Workflow
     def note          ; @attrs['note']         ; end
     def version       ; @attrs['version']      ; end
     def priority      ; @attrs['priority']     ; end
-    def completed?    ; status == 'completed'  ; end
+    def completed?    ; %w(completed skipped).include?(status); end
     def error?        ; status == 'error'      ; end
     def waiting?      ; status == 'waiting'    ; end
     def date_time     ; @attrs['datetime']     ; end


### PR DESCRIPTION
@lmcglohon @peetucket This PR fixes a problem with `to_solr` that produces incorrect facets for the `wf_xxx_ssim` fields.

For example,

```
"releaseWF:release-publish",
"releaseWF:release-publish:waiting",
"releaseWF:release-publish:ready"
```

should be

```
"releaseWF:release-publish",
"releaseWF:release-publish:completed"
```

There are no existing tests that deal with the state computations, and as far as I can tell, no existing specs on the computation of the workflow facets.