### PR TITLE
fix for when APOs do not have administrativeMetadata datastream

### DIFF
--- a/lib/dor/models/concerns/governable.rb
+++ b/lib/dor/models/concerns/governable.rb
@@ -19,6 +19,8 @@ module Dor
       return 'default' if admin_policy_object.nil?  # TODO: log warning?
 
       admin_md = admin_policy_object.datastreams['administrativeMetadata']
+      return 'default' unless admin_md.respond_to?(:default_workflow_lane) # Some APOs don't have this datastream
+
       lane = admin_md.default_workflow_lane
       return 'default' if lane.blank?
       lane

--- a/spec/models/concerns/governable_spec.rb
+++ b/spec/models/concerns/governable_spec.rb
@@ -252,6 +252,12 @@ describe Dor::Governable do
       allow(@item).to receive(:admin_policy_object) { apo }
       expect(@item.default_workflow_lane).to eq 'default'
     end
+    it "returns the value 'default' if the object's APO does not have administrativeMetadata" do
+      apo = instantiate_fixture('druid:fg890hi1234', Dor::AdminPolicyObject)
+      allow(@item).to receive(:admin_policy_object) { apo }
+      allow(apo.datastreams).to receive(:[]).with('administrativeMetadata').and_return(nil)
+      expect(@item.default_workflow_lane).to eq 'default'
+    end
     it "returns the value 'default' for a newly created object" do
       apo  = instantiate_fixture('druid:zt570tx3016', Dor::AdminPolicyObject)
       item = GovernableItem.new


### PR DESCRIPTION
for an example in production see druid:xx313vx3974