### PR TITLE
registration_service_spec: add specs for #create_from_request

### DIFF
--- a/spec/services/registration_service_spec.rb
+++ b/spec/services/registration_service_spec.rb
@@ -307,6 +307,7 @@ describe Dor::RegistrationService do
         obj = Dor::RegistrationService.register_object(@params)
         expect(obj.label).to eq('a' * 254)
       end
+
       it 'sets workflow priority when passed in' do
         expect_any_instance_of(Dor::Item).to receive(:create_workflow).with('digitizationWF', false, 50)
         @params[:workflow_priority] = 50
@@ -315,5 +316,48 @@ describe Dor::RegistrationService do
       end
     end # context common cases
 
+  end
+
+  context '#create_from_request' do
+    before :each do
+      allow(Dor::SuriService).to receive(:mint_id).and_return(@pid)
+      allow(Dor::SearchService).to receive(:query_by_id).and_return([])
+      allow(ActiveFedora::Base).to receive(:connection_for_pid).and_return(@mock_repo)
+      # allow(Dor::SearchService).to receive(:solr).and_return(@mock_solr)
+      allow_any_instance_of(Dor::Item).to receive(:save).and_return(true)
+      # allow_any_instance_of(Dor::Collection).to receive(:save).and_return(true)
+      allow_any_instance_of(Dor::Item).to receive(:create).and_return(true)
+
+      @params = {
+        :object_type   => 'item',
+        :admin_policy  => 'druid:fg890hi1234',
+        :label         => 'web-archived-crawl for http://www.example.org',
+        :source_id     => 'sul:SOMETHING-www.example.org'
+      }
+    end
+
+    context 'exception should be raised for' do
+      it 'a source ID not having exactly one colon' do
+        expect { Dor::RegistrationService.create_from_request(@params) }.not_to raise_error
+        # Generic error is raised in #ids_to_hash before code gets to specific Source ID error message
+        @params[:source_id] = 'sul:SOMETHING-http://www.example.org'
+        exp_regex = /invalid number of elements/
+        expect { Dor::RegistrationService.create_from_request(@params) }.to raise_error(ArgumentError, exp_regex)
+        # Execution gets into IdentityMetadataDS code for specific error
+        @params[:source_id] = 'no-colon'
+        exp_regex = /Source ID must follow the format 'namespace:value'/
+        expect { Dor::RegistrationService.create_from_request(@params) }.to raise_error(ArgumentError, exp_regex)
+      end
+      it 'other_id with more than one colon' do
+        @params[:other_id] = 'no-colon'
+        expect { Dor::RegistrationService.create_from_request(@params) }.not_to raise_error
+        @params[:other_id] = 'catkey:000'
+        expect { Dor::RegistrationService.create_from_request(@params) }.not_to raise_error
+        # Generic error is raised in #ids_to_hash
+        @params[:other_id] = 'catkey:oop:sie'
+        exp_regex = /invalid number of elements/
+        expect { Dor::RegistrationService.create_from_request(@params) }.to raise_error(ArgumentError, exp_regex)
+      end
+    end
   end
 end


### PR DESCRIPTION
do not merge - this is morphing!

Adding these specs to 'document' that source_id must have exactly one colon -- this is a problem encountered by the was-registrar rails app when trying to register an object.  

(per conversation with @eefahy on "how do we sustain-ably document the API being used by other apps?" in the context of doing better monitoring and testing robots.)