### PR TITLE
Add Hydrus model shims

### DIFF
--- a/lib/dor-services.rb
+++ b/lib/dor-services.rb
@@ -155,4 +155,6 @@ module Dor
   end
 
   eager_load!
+
+  require 'dor/utils/hydrus_shims'
 end

--- a/lib/dor/utils/hydrus_shims.rb
+++ b/lib/dor/utils/hydrus_shims.rb
@@ -1,0 +1,11 @@
+module Hydrus
+  # These shims allow DOR to interact seamlessly with Hydrus' custom models
+  class Item < Dor::Item
+  end
+
+  class Collection < Dor::Collection
+  end
+
+  class AdminPolicyObject < Dor::AdminPolicyObject
+  end
+end


### PR DESCRIPTION
I'm giving up our fight against ActiveFedora that allows us to support a different notion of data integrity than the rest of the Hydra community. This will allow DOR-based services to transparently load Hydrus models using any and all of the normal ActiveFedora behaviors.