### PR TITLE
allow source_id and other_id values to have colons

### DIFF
--- a/lib/dor/datastreams/identity_metadata_ds.rb
+++ b/lib/dor/datastreams/identity_metadata_ds.rb
@@ -51,8 +51,7 @@ class IdentityMetadataDS < ActiveFedora::OmDatastream
       node.remove unless node.nil?
       return nil
     end
-    parts = value.split(':').map(&:strip)
-    # parts = value.split(/:/, 2).map(&:strip) # if we needed to allow colons in values or bunched colon separators
+    parts = value.split(':', 2).map(&:strip)
     raise ArgumentError, "Source ID must follow the format 'namespace:value', not '#{value}'" unless
       parts.length == 2 && parts[0].present? && parts[1].present?
     node ||= ng_xml.root.add_child('<sourceId/>').first

--- a/lib/dor/services/registration_service.rb
+++ b/lib/dor/services/registration_service.rb
@@ -187,7 +187,7 @@ module Dor
 
       def ids_to_hash(ids)
         return nil if ids.nil?
-        Hash[Array(ids).map { |id| id.split(/:/) }]
+        Hash[Array(ids).map { |id| id.split(':', 2) }]
       end
     end
   end

--- a/spec/datastreams/identity_metadata_spec.rb
+++ b/spec/datastreams/identity_metadata_spec.rb
@@ -35,7 +35,7 @@ describe Dor::IdentityMetadataDS do
       expect(@dsdoc.sourceId).to eq('sulair:bb110sm8219')
     end
 
-    it 'should be able to read ID fields as attributes' do
+    it 'can read ID fields as attributes' do
       expect(@dsdoc.objectId).to eq('druid:bb110sm8219')
       expect(@dsdoc.otherId).to eq(['mdtoolkit:bb110sm8219', 'uuid:b382ee92-da77-11e0-9036-0016034322e4'])
       expect(@dsdoc.otherId('mdtoolkit')).to eq(['bb110sm8219'])
@@ -44,7 +44,7 @@ describe Dor::IdentityMetadataDS do
       expect(@dsdoc.sourceId).to eq('sulair:bb110sm8219')
     end
 
-    it 'should be able to set the (stripped) sourceID' do
+    it 'sets the (stripped) sourceID' do
       resultxml = <<-EOF
         <identityMetadata>
           <objectCreator>DOR</objectCreator>
@@ -90,17 +90,16 @@ describe Dor::IdentityMetadataDS do
       end
     end
 
-    it 'should raise on malformed sourceIDs' do
+    it 'raises ArgumentError on malformed sourceIDs' do
       expect{@dsdoc.sourceId = 'NotEnoughColons'}.to raise_exception(ArgumentError)
       expect{@dsdoc.sourceId = ':EmptyFirstPart'}.to raise_exception(ArgumentError)
       expect{@dsdoc.sourceId = 'WhitespaceSecondPart:  '}.to raise_exception(ArgumentError)
       expect{@dsdoc.sourceId = 'WhitespaceSecondPart:  '}.to raise_exception(ArgumentError)
     end
 
-    it 'should raise on a value containing too many colons' do
-      # This may need to be loosened in the future to accommodate colon-having values from as-yet-unknown sources
-      expect{@dsdoc.sourceId = 'Too:Many:Parts'}.to raise_exception(ArgumentError)
-      expect{@dsdoc.sourceId = 'Too::ManyColons'}.to raise_exception(ArgumentError)
+    it 'does not raise error on a sourceId with multiple colons' do
+      expect{@dsdoc.sourceId = 'Too:Many:Parts'}.not_to raise_exception
+      expect{@dsdoc.sourceId = 'Too::ManyColons'}.not_to raise_exception
     end
 
     it 'creates a simple default with #new' do
@@ -108,7 +107,7 @@ describe Dor::IdentityMetadataDS do
       expect(new_doc.to_xml).to be_equivalent_to '<identityMetadata/>'
     end
 
-    it 'should properly add elements' do
+    it 'properly adds elements' do
       resultxml = <<-EOF
         <identityMetadata>
           <objectId>druid:ab123cd4567</objectId>

--- a/spec/models/concerns/identifiable_spec.rb
+++ b/spec/models/concerns/identifiable_spec.rb
@@ -40,8 +40,6 @@ describe Dor::Identifiable do
 
   describe 'source_id= (AKA set_source_id)' do
     it 'raises on unsalvageable values' do
-      expect{item.source_id = 'Too:Many:Colons'}.to raise_error ArgumentError
-      expect{item.source_id = 'Still::TooMany'}.to raise_error ArgumentError
       expect{item.source_id = 'NotEnoughColons'}.to raise_error ArgumentError
       expect{item.source_id = ':EmptyFirstPart'}.to raise_error ArgumentError
       expect{item.source_id = 'WhitespaceSecondPart:   '}.to raise_error ArgumentError
@@ -59,6 +57,12 @@ describe Dor::Identifiable do
     it 'should do normalization via identityMetadata.sourceID=' do
       item.source_id = ' SourceX :  Value Y  '
       expect(item.source_id).to eq('SourceX:Value Y')
+    end
+    it 'allows colons in the value' do
+      item.source_id = 'one:two:three'
+      expect(item.source_id).to eq('one:two:three')
+      item.source_id = 'one::two::three'
+      expect(item.source_id).to eq('one::two::three')
     end
     it 'should delete the sourceId node on nil or empty-string' do
       item.source_id = nil


### PR DESCRIPTION
Motivated by errors thrown when registering web archive seed objects with source_id values of the form `sul:SOMETHING-http://www.foo.org`

This solution also implies a loosening of the data validation requirements in argo for source_id.  See https://github.com/sul-dlss/argo/pull/915.