### PR TITLE
When publishing metadata, use #content instead of #to_xml

### DIFF
--- a/lib/dor/models/concerns/publishable.rb
+++ b/lib/dor/models/concerns/publishable.rb
@@ -84,7 +84,7 @@ module Dor
         dc_xml = generate_dublin_core.to_xml {|config| config.no_declaration}
         DigitalStacksService.transfer_to_document_store(pid, dc_xml, 'dc')
         %w(identityMetadata contentMetadata rightsMetadata).each do |stream|
-          DigitalStacksService.transfer_to_document_store(pid, datastreams[stream].to_xml, stream) if datastreams[stream]
+          DigitalStacksService.transfer_to_document_store(pid, datastreams[stream].content.to_s, stream) if datastreams[stream]
         end
         DigitalStacksService.transfer_to_document_store(pid, public_xml, 'public')
         DigitalStacksService.transfer_to_document_store(pid, generate_public_desc_md, 'mods')


### PR DESCRIPTION
for compatibility with all datastreams, including datastreams that are not declared as part of the model for a class.