### PR TITLE
update version of jhove

### DIFF
--- a/dor-services.gemspec
+++ b/dor-services.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |s|
   # It will not add these as dependencies if you require dor-services for other projects
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'jhove-service', '~> 1.0.1'
+  s.add_development_dependency 'jhove-service', '>= 1.1.1'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '~> 10'
   s.add_development_dependency 'rspec', '~> 3.1'

--- a/spec/fixtures/workspace/dd/116/zh/0343/dd116zh0343/metadata/technicalMetadata.xml
+++ b/spec/fixtures/workspace/dd/116/zh/0343/dd116zh0343/metadata/technicalMetadata.xml
@@ -1,7 +1,7 @@
 <technicalMetadata objectId='druid:dd116zh0343' datetime='2012-07-19T22:35:34Z'
     xmlns:jhove='http://hul.harvard.edu/ois/xml/ns/jhove'
     xmlns:mix='http://www.loc.gov/mix/v10'
-    xmlns:textmd='info:lc/xmlns/textMD-v3' >
+    xmlns:textmd='info:lc/xmlns/textMD-v3'>
   <file id='folder1PuSu/story1u.txt'>
     <jhove:reportingModule release='1.3' date='2006-09-05'>ASCII-hul</jhove:reportingModule>
     <jhove:format>ASCII</jhove:format>
@@ -36,8 +36,13 @@
   </file>
   <file id='folder1PuSu/story3m.txt'>
     <jhove:reportingModule release='1.3' date='2006-09-05'>ASCII-hul</jhove:reportingModule>
+    <jhove:lastModified>2012-08-28T09:44:26-07:00</jhove:lastModified>
+    <jhove:size>5941</jhove:size>
     <jhove:format>ASCII</jhove:format>
     <jhove:status>Well-Formed and valid</jhove:status>
+    <jhove:sigMatch>
+      <jhove:module>WARC-kb</jhove:module>
+    </jhove:sigMatch>
     <jhove:mimeType>text/plain; charset=US-ASCII</jhove:mimeType>
     <jhove:properties>
       <textmd:textMD>
@@ -52,8 +57,13 @@
   </file>
   <file id='folder1PuSu/story5a.txt'>
     <jhove:reportingModule release='1.3' date='2006-09-05'>ASCII-hul</jhove:reportingModule>
+    <jhove:lastModified>2012-08-28T09:44:26-07:00</jhove:lastModified>
+    <jhove:size>3614</jhove:size>
     <jhove:format>ASCII</jhove:format>
     <jhove:status>Well-Formed and valid</jhove:status>
+    <jhove:sigMatch>
+      <jhove:module>WARC-kb</jhove:module>
+    </jhove:sigMatch>
     <jhove:mimeType>text/plain; charset=US-ASCII</jhove:mimeType>
     <jhove:properties>
       <textmd:textMD>
@@ -100,8 +110,13 @@
   </file>
   <file id='folder2PdSa/story8m.txt'>
     <jhove:reportingModule release='1.3' date='2006-09-05'>ASCII-hul</jhove:reportingModule>
+    <jhove:lastModified>2012-08-28T09:44:26-07:00</jhove:lastModified>
+    <jhove:size>5645</jhove:size>
     <jhove:format>ASCII</jhove:format>
     <jhove:status>Well-Formed and valid</jhove:status>
+    <jhove:sigMatch>
+      <jhove:module>WARC-kb</jhove:module>
+    </jhove:sigMatch>
     <jhove:mimeType>text/plain; charset=US-ASCII</jhove:mimeType>
     <jhove:properties>
       <textmd:textMD>
@@ -116,8 +131,13 @@
   </file>
   <file id='folder2PdSa/storyAa.txt'>
     <jhove:reportingModule release='1.3' date='2006-09-05'>ASCII-hul</jhove:reportingModule>
+    <jhove:lastModified>2012-08-28T09:44:26-07:00</jhove:lastModified>
+    <jhove:size>10717</jhove:size>
     <jhove:format>ASCII</jhove:format>
     <jhove:status>Well-Formed and valid</jhove:status>
+    <jhove:sigMatch>
+      <jhove:module>WARC-kb</jhove:module>
+    </jhove:sigMatch>
     <jhove:mimeType>text/plain; charset=US-ASCII</jhove:mimeType>
     <jhove:properties>
       <textmd:textMD>
@@ -164,8 +184,13 @@
   </file>
   <file id='folder3PaSd/storyDm.txt'>
     <jhove:reportingModule release='1.3' date='2006-09-05'>ASCII-hul</jhove:reportingModule>
+    <jhove:lastModified>2012-08-28T09:44:26-07:00</jhove:lastModified>
+    <jhove:size>25336</jhove:size>
     <jhove:format>ASCII</jhove:format>
     <jhove:status>Well-Formed and valid</jhove:status>
+    <jhove:sigMatch>
+      <jhove:module>WARC-kb</jhove:module>
+    </jhove:sigMatch>
     <jhove:mimeType>text/plain; charset=US-ASCII</jhove:mimeType>
     <jhove:properties>
       <textmd:textMD>
@@ -180,8 +205,13 @@
   </file>
   <file id='folder3PaSd/storyFa.txt'>
     <jhove:reportingModule release='1.3' date='2006-09-05'>ASCII-hul</jhove:reportingModule>
+    <jhove:lastModified>2012-08-28T09:44:26-07:00</jhove:lastModified>
+    <jhove:size>28726</jhove:size>
     <jhove:format>ASCII</jhove:format>
     <jhove:status>Well-Formed and valid</jhove:status>
+    <jhove:sigMatch>
+      <jhove:module>WARC-kb</jhove:module>
+    </jhove:sigMatch>
     <jhove:mimeType>text/plain; charset=US-ASCII</jhove:mimeType>
     <jhove:properties>
       <textmd:textMD>

--- a/spec/fixtures/workspace/jq/937/jp/0017/jq937jp0017/metadata/technicalMetadata.xml
+++ b/spec/fixtures/workspace/jq/937/jp/0017/jq937jp0017/metadata/technicalMetadata.xml
@@ -1,9 +1,11 @@
 <technicalMetadata objectId='druid:jq937jp0017' datetime='2012-07-19T23:27:00Z'
     xmlns:jhove='http://hul.harvard.edu/ois/xml/ns/jhove'
     xmlns:mix='http://www.loc.gov/mix/v10'
-    xmlns:textmd='info:lc/xmlns/textMD-v3' >
+    xmlns:textmd='info:lc/xmlns/textMD-v3'>
   <file id='page-1.jpg'>
     <jhove:reportingModule release='1.2' date='2007-02-13'>JPEG-hul</jhove:reportingModule>
+    <jhove:lastModified>2012-08-28T09:44:26-07:00</jhove:lastModified>
+    <jhove:size>32915</jhove:size>
     <jhove:format>JPEG</jhove:format>
     <jhove:version>1.01</jhove:version>
     <jhove:status>Well-Formed and valid</jhove:status>
@@ -54,6 +56,8 @@
   </file>
   <file id='page-2.jpg'>
     <jhove:reportingModule release='1.2' date='2007-02-13'>JPEG-hul</jhove:reportingModule>
+    <jhove:lastModified>2012-08-28T09:44:26-07:00</jhove:lastModified>
+    <jhove:size>39539</jhove:size>
     <jhove:format>JPEG</jhove:format>
     <jhove:version>1.01</jhove:version>
     <jhove:status>Well-Formed and valid</jhove:status>

--- a/spec/services/technical_metadata_service_spec.rb
+++ b/spec/services/technical_metadata_service_spec.rb
@@ -301,8 +301,11 @@ describe Dor::TechnicalMetadataService do
       new_techmd = @new_file_techmd[id]
       deltas = @deltas[id]
       merged_nodes = Dor::TechnicalMetadataService.merge_file_nodes(old_techmd, new_techmd, deltas)
-      final_techmd = Dor::TechnicalMetadataService.build_technical_metadata("druid:#{id}", merged_nodes)
-      expect(final_techmd.gsub(/datetime=["'].*?["']/, '')).to be_equivalent_to @expected_techmd[id].gsub(/datetime=["'].*?["']/, '')
+
+      # the final and expected_techmd need to be scrubbed of dates in a couple spots for the comparison to match since these will vary from test run to test run
+      final_techmd = Dor::TechnicalMetadataService.build_technical_metadata("druid:#{id}", merged_nodes).gsub(/datetime=["'].*?["']/, '').gsub(/<jhove:lastModified>.*?<\/jhove:lastModified>/, '')
+      expected_techmd = @expected_techmd[id].gsub(/datetime=["'].*?["']/, '').gsub(/<jhove:lastModified>.*?<\/jhove:lastModified>/, '')
+      expect(final_techmd).to be_equivalent_to expected_techmd
     end
   end
 


### PR DESCRIPTION
update dor-services to use latest jhove-service gem to get techMD to use latest jhove

needed to update techMD tests since jhove output is now slightly different and has dates in a couple extra places that need to be stripped out for comparison in tests