### PR TITLE
Move connection creation out of the configuration

### DIFF
--- a/lib/dor/certificate_authenticated_rest_resource_factory.rb
+++ b/lib/dor/certificate_authenticated_rest_resource_factory.rb
@@ -1,0 +1,37 @@
+require 'dor/rest_resource_factory'
+# Creates RestClient::Resources with client ssl keys for various connections
+module Dor
+  class CertificateAuthenticatedRestResourceFactory < RestResourceFactory
+
+    private
+
+    # @return [Hash] options for creating a RestClient::Resource
+    def connection_options
+      params = super
+      params[:ssl_client_cert] = cert if cert
+      params[:ssl_client_key]  = key if key
+    end
+
+    # @return [OpenSSL::X509::Certificate]
+    def cert
+      @cert ||= OpenSSL::X509::Certificate.new(File.read(cert_file)) if cert_file
+    end
+
+    def cert_file
+      Dor::Config.ssl.cert_file
+    end
+
+    def key_file
+      Dor::Config.ssl.key_file
+    end
+
+    def key_pass
+      Dor::Config.ssl.key_pass
+    end
+
+    # @return [OpenSSL::PKey::RSA]
+    def key
+      @key ||= OpenSSL::PKey::RSA.new(File.read(key_file), key_pass) if key_file
+    end
+  end
+end

--- a/lib/dor/rest_resource_factory.rb
+++ b/lib/dor/rest_resource_factory.rb
@@ -1,0 +1,39 @@
+# Creates RestClient::Resources for various connections
+module Dor
+  class RestResourceFactory
+    include Singleton
+
+    # @param type [Symbol] the type of connection to create (e.g. :fedora)
+    # @return [RestClient::Resource]
+    def self.create(type)
+      instance.create(type)
+    end
+
+    # @param type [Symbol] the type of connection to create (e.g. :fedora)
+    # @return [RestClient::Resource]
+    def create(type)
+      RestClient::Resource.new(url_for(type), connection_options)
+    end
+
+    private
+
+    # @param type [Symbol] the type of connection to create (e.g. :fedora)
+    # @return [String] the url to connect to.
+    def url_for(type)
+      connection_configuration(type).url
+    end
+
+    # @param type [Symbol] the type of connection to create (e.g. :fedora)
+    # @return [#url] the configuration for the connection
+    def connection_configuration(type)
+      Dor::Config.fetch(type)
+    rescue KeyError
+      raise "ERROR: Unable to find a configuration for #{type}"
+    end
+
+    # @return [Hash] options for creating a RestClient::Resource
+    def connection_options
+      {}
+    end
+  end
+end


### PR DESCRIPTION
Classes should only have one responsibility.

This deprecates `Dor::Config#make_rest_client` and
`Dor::Config#autoconfigure`