### PR TITLE
Add support for a @role attribute on a contentMetadata's file element

### DIFF
--- a/lib/dor/datastreams/content_metadata_ds.rb
+++ b/lib/dor/datastreams/content_metadata_ds.rb
@@ -95,9 +95,10 @@ module Dor
           counts['content_file'] += 1
           preserved_size += file['size'].to_i if file['preserve'] == 'yes'
           shelved_size += file['size'].to_i if file['shelve'] == 'yes'
-          next unless file['shelve'] == 'yes'
-          counts['shelved_file'] += 1
-          first_shelved_image ||= file['id'] if file['id'] =~ /jp2$/
+          if file['shelve'] == 'yes'
+            counts['shelved_file'] += 1
+            first_shelved_image ||= file['id'] if file['id'] =~ /jp2$/
+          end
           mime_types << file['mimetype']
         end
       end

--- a/spec/datastreams/content_metadata_ds_spec.rb
+++ b/spec/datastreams/content_metadata_ds_spec.rb
@@ -200,7 +200,7 @@ describe Dor::ContentMetadataDS do
     it 'should generate required fields' do
       expected = {
         'content_type_ssim'               => 'map',
-        'content_file_mimetypes_ssim'     => ['image/jp2'],
+        'content_file_mimetypes_ssim'     => ['image/jp2', 'image/gif', 'image/tiff'],
         'shelved_content_file_count_itsi' => 1,
         'resource_count_itsi'             => 1,
         'content_file_count_itsi'         => 3,


### PR DESCRIPTION
Related to https://github.com/sul-dlss/content_search/issues/47.

For OCR files, we're strongly considering adding a role="transcription" attribute to the <file> element that references the OCR'ed (or manually transcribed, or speech-to-text'ed, etc) content. This PR makes it possible to pass this attribute through our stack.

The `@role` attribute was spec'ed, but never implemented, and was initially described as:

> Possible attribute to distinguish like files in a resource where a published resource wants alternate representations, e.f., cropped/uncropped for a single resource.


