### PR TITLE
Fix outdated call to #next_pid in SuriService

### DIFF
--- a/lib/dor/services/suri_service.rb
+++ b/lib/dor/services/suri_service.rb
@@ -17,8 +17,14 @@ module Dor
         ids = resource["identifiers?quantity=#{quantity}"].post('').chomp.split(/\n/).collect { |id| "#{Config.suri.id_namespace}:#{id.strip}" }
       else
         repo = ActiveFedora::Base.respond_to?(:connection_for_pid) ? ActiveFedora::Base.connection_for_pid(0) : ActiveFedora.fedora.connection
-        resp = Nokogiri::XML(repo.next_pid(numPIDs: quantity))
+        resp = Nokogiri::XML(repo.api.next_pid(numPIDs: quantity))
         ids = resp.xpath('/pidList/pid').collect { |node| node.text }
+        # With modernish (circa 2015/6) dependencies, including Nokogiri and
+        # ActiveFedora/Rubydora, `ids` is `[]` above. If that is the case, try
+        # the XPath that works (confirmed with most recent `hydra_etd` work)
+        if ids.empty? && resp.root.namespaces.any?
+          ids = resp.xpath('/xmlns:pidList/xmlns:pid').collect { |node| node.text }
+        end
       end
       want_array ? ids : ids.first
 

--- a/spec/services/registration_service_spec.rb
+++ b/spec/services/registration_service_spec.rb
@@ -6,7 +6,7 @@ describe Dor::RegistrationService do
 
   before :each do
     @pid = 'druid:ab123cd4567'
-    @mock_repo = double(Rubydora::Repository, :url => 'foo')
+    @mock_repo = instance_double(Rubydora::Repository)
     @apo = instantiate_fixture('druid:fg890hi1234', Dor::AdminPolicyObject)
     allow(@apo).to receive(:new_record?).and_return false
     allow(Dor).to receive(:find).with('druid:fg890hi1234').and_return(@apo)

--- a/spec/services/suri_service_spec.rb
+++ b/spec/services/suri_service_spec.rb
@@ -51,7 +51,10 @@ describe Dor::SuriService do
     end
 
     before :each do
-      @mock_repo = double(Rubydora::Repository)
+      @mock_repo = instance_double(Rubydora::Repository)
+      @mock_client = instance_double(Rubydora::RestApiClient)
+      allow(@mock_repo).to receive(:api).and_return(@mock_client)
+
       if ActiveFedora::Base.respond_to?(:connection_for_pid)
         allow(ActiveFedora::Base).to receive(:connection_for_pid).and_return(@mock_repo)
       else
@@ -70,7 +73,7 @@ describe Dor::SuriService do
         <pid>pid:123</pid>
       </pidList>
       EOXML
-      expect(@mock_repo).to receive(:next_pid).with(:numPIDs => 1).and_return(xml_response)
+      expect(@mock_client).to receive(:next_pid).with(:numPIDs => 1).and_return(xml_response)
       expect(Dor::SuriService.mint_id).to eq('pid:123')
       Dor::Config.suri.pop
     end
@@ -84,7 +87,7 @@ describe Dor::SuriService do
         <pid>pid:789</pid>
       </pidList>
       EOXML
-      expect(@mock_repo).to receive(:next_pid).with(:numPIDs => 3).and_return(xml_response)
+      expect(@mock_client).to receive(:next_pid).with(:numPIDs => 3).and_return(xml_response)
       expect(Dor::SuriService.mint_id(3)).to eq(['pid:123', 'pid:456', 'pid:789'])
       Dor::Config.suri.pop
     end


### PR DESCRIPTION
If `Config.suri.mint_ids` is false, the SuriService raises a NoMethodError calling `#next_pid` on a Rubydora::Repository instance. Rubydora::Repository instances do not define this method; the method is defined on Rubydora::RestApiClient which can be accessed via `#api` on the repository.

Additionally, the xpath that is used in the same `else` clause no longer parses pids out of the `pidList`. I have added code that tries a second XPath if the first fails.

This bug has been hidden for 6ish years due to how the spec is mocking things out.

I made these changes so the latest hydra_etd work can use dor-services without patching around the SuriService.