### PR TITLE
Make SimpleDublinCoreDs build the DC datastream such that it matches what's in Fedora

### DIFF
--- a/lib/dor/datastreams/simple_dublin_core_ds.rb
+++ b/lib/dor/datastreams/simple_dublin_core_ds.rb
@@ -15,11 +15,12 @@ class SimpleDublinCoreDs < ActiveFedora::OmDatastream
 
   def self.xml_template
     builder = Nokogiri::XML::Builder.new do |xml|
-      xml.dc(:xmlns => 'http://www.openarchives.org/OAI/2.0/oai_dc/', 'xmlns:dc' => 'http://purl.org/dc/elements/1.1/') {
-        xml['dc'].title
-        xml['dc'].creator
-        xml['dc'].identifier
-      }
+      xml['oai_dc'].dc(
+        'xmlns:oai_dc' => 'http://www.openarchives.org/OAI/2.0/oai_dc/',
+        'xmlns:dc' => 'http://purl.org/dc/elements/1.1/',
+        'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+        'xsi:schemaLocation' => 'http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd',
+      )
     end
 
     builder.doc


### PR DESCRIPTION
Changes include:

* Add `oai_dc` namespace to root node
* Declare `oai_dc` namespace so it can be used in root node
* Add XSI namespace so the `schemaLocation` can be asserted on the root node
* Remove empty and unnecessary title, creator, and identifier fields from XML template

Without these changes, the `hydra_etd` app cannot use `Dor::SimpleDublinCoreDs` and must thus create its own DC datastream, resulting in (near-)duplicate code.

This work was driven by sul-dlss/hydra_etd#24, which is part of the work cycle to update the ETD application to use quasi-modern, more secure dependencies.