### PR TITLE
Travis matrix intends to test *different* scenarios

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ rvm:
 
 env:
   - 'RAILS_VERSION="~> 4.2"'
-  - 'RAILS_VERSION="~> 5.0"'
-  - 'RAILS_VERSION="~> 5.1"'
+  - 'RAILS_VERSION="~> 5.0.0"'
+  - 'RAILS_VERSION="~> 5.1.0"'
 
 matrix:
   include:


### PR DESCRIPTION
These lines both resolved to Rails 5.2.0, for example.  The existence of a 5.1.x version means that `~> 5.0` would always resolve to the same thing as `~> 5.1`.

Fixes #350 