### PR TITLE
SdrIngestService:  trigger new preservationIngestWF instead of sdrIngestWF

### DIFF
--- a/lib/dor/services/sdr_ingest_service.rb
+++ b/lib/dor/services/sdr_ingest_service.rb
@@ -1,6 +1,8 @@
 require 'moab/stanford'
 
 module Dor
+  # Note: This should probably live in common-accessioning robot sdr-ingest-transfer
+  #  as that is the only robot that uses it.  See also preservable concern.
   class SdrIngestService
 
     # @param [Dor::Item] dor_item The representation of the digital object
@@ -40,6 +42,8 @@ module Dor
     rescue Exception => e
       raise Dor::Exception, "Error exporting new object version to bag: #{e.message}"
     end
+
+    # Note: the following methods should probably all be private
 
     # @param [String] druid The object identifier
     # @return [Moab::SignatureCatalog] the catalog of all files previously ingested

--- a/lib/dor/services/sdr_ingest_service.rb
+++ b/lib/dor/services/sdr_ingest_service.rb
@@ -38,7 +38,7 @@ module Dor
       # start SDR preservation workflow (but do not create the workflows datastream)
       dor_item.create_workflow('preservationIngestWF', false)
     rescue Exception => e
-      raise Dor::Exception, 'Export failure'
+      raise Dor::Exception, "Error exporting new object version to bag: #{e.message}"
     end
 
     # @param [String] druid The object identifier

--- a/lib/dor/services/sdr_ingest_service.rb
+++ b/lib/dor/services/sdr_ingest_service.rb
@@ -5,7 +5,7 @@ module Dor
 
     # @param [Dor::Item] dor_item The representation of the digital object
     # @param [String] agreement_id  depreciated, included for backward compatability with common-accessoning
-    # @return [void] Create the moab manifests, export data to a BagIt bag, kick off the SDR ingest workflow
+    # @return [void] Create the Moab/bag manifests for new version, export data to BagIt bag, kick off the SDR preservation workflow
     def self.transfer(dor_item, agreement_id = nil)
       druid = dor_item.pid
       workspace = DruidTools::Druid.new(druid, Dor::Config.sdr.local_workspace_root)
@@ -35,8 +35,8 @@ module Dor
       bagger.deposit_group('metadata', metadata_dir)
       bagger.create_tagfiles
       verify_bag_structure(bag_dir)
-      # Now bootstrap SDR workflow. but do not create the workflows datastream
-      dor_item.create_workflow('sdrIngestWF', false)
+      # start SDR preservation workflow (but do not create the workflows datastream)
+      dor_item.create_workflow('preservationIngestWF', false)
     rescue Exception => e
       raise Dor::Exception, 'Export failure'
     end

--- a/spec/services/sdr_ingest_service_spec.rb
+++ b/spec/services/sdr_ingest_service_spec.rb
@@ -64,7 +64,7 @@ describe Dor::SdrIngestService do
     before :each do
       druid = 'druid:dd116zh0343'
       @dor_item = double('dor_item')
-      expect(@dor_item).to receive(:create_workflow).with('sdrIngestWF', false)
+      expect(@dor_item).to receive(:create_workflow).with('preservationIngestWF', false)
       allow(@dor_item).to receive(:pid).and_return(druid)
       signature_catalog = Moab::SignatureCatalog.read_xml_file(@fixtures.join('sdr_repo/dd116zh0343/v0001/manifests'))
       @metadata_dir = @fixtures.join('workspace/dd/116/zh/0343/dd116zh0343/metadata')


### PR DESCRIPTION
We have new robot code at parity with the old sdr-preservation-core code;  the new robot code has been vetted to work in production;  this change is to allow common-accessioning to kick off the new preservationIngestWF  instead of sdrIngestWF, which will be deprecated.

Also improved an error message and added some comments.