### PR TITLE
Assign a PID when saving rather than on initialization

### DIFF
--- a/lib/dor/models/concerns/identifiable.rb
+++ b/lib/dor/models/concerns/identifiable.rb
@@ -18,13 +18,13 @@ module Dor
         @object_type = str
         Dor.registered_classes[str] = self
       end
-    end
 
-    def initialize(attrs = {})
-      if Dor::Config.suri.mint_ids && !attrs[:pid]
-        attrs = attrs.merge!({:pid => Dor::SuriService.mint_id, :new_object => true})
+      # Overrides the method in ActiveFedora to mint a pid using SURI rather
+      # than the default Fedora sequence
+      def assign_pid(_)
+        return Dor::SuriService.mint_id if Dor::Config.suri.mint_ids
+        super
       end
-      super
     end
 
     # helper method to get the tags as an array


### PR DESCRIPTION
This will allow us to do:

```ruby
form_for Dor::Item.new
```
without calling SURI to mint a pid