### PR TITLE
Add basic authentication to RestClient::Resource

### DIFF
--- a/config/config_defaults.yml
+++ b/config/config_defaults.yml
@@ -16,6 +16,8 @@
 :metadata:
   :catalog:
     :url:
+    :user:
+    :pass:
 :sdr:
   :local_workspace_root: /dor/workspace
   :local_export_home: /dor/export

--- a/lib/dor/services/metadata_handlers/catalog_handler.rb
+++ b/lib/dor/services/metadata_handlers/catalog_handler.rb
@@ -2,7 +2,9 @@ require 'rest-client'
 
 handler = Class.new do
   def fetch(prefix, identifier)
-    client = RestClient::Resource.new(Dor::Config.metadata.catalog.url)
+    client = RestClient::Resource.new(Dor::Config.metadata.catalog.url,
+                                      Dor::Config.metadata.catalog.user,
+                                      Dor::Config.metadata.catalog.pass)
     client["?#{prefix.chomp}=#{identifier.chomp}"].get
   end
 

--- a/spec/services/metadata_service_spec.rb
+++ b/spec/services/metadata_service_spec.rb
@@ -40,7 +40,9 @@ describe Dor::MetadataService do
       @mods = File.read(File.join(@specdir, 'fixtures', 'mods_record.xml'))
       @mock_resource = double('catalog-resource', :get => @mods)
       allow(@mock_resource).to receive(:[]).and_return(@mock_resource)
-      expect(RestClient::Resource).to receive(:new).with(Dor::Config.metadata.catalog.url).and_return(@mock_resource)
+      expect(RestClient::Resource).to receive(:new).with(Dor::Config.metadata.catalog.url,
+                                                         Dor::Config.metadata.catalog.user,
+                                                         Dor::Config.metadata.catalog.pass).and_return(@mock_resource)
     end
 
     it 'should fetch a record based on barcode' do

--- a/spec/support/dor_config.rb
+++ b/spec/support/dor_config.rb
@@ -19,6 +19,8 @@ Dor.configure do
 
   metadata do
     catalog.url 'http://example.edu/catalog/mods'
+    catalog.user 'user'
+    catalog.pass 'pass'
   end
 
   solr.url         'https://example.edu/solr/solrizer'


### PR DESCRIPTION
This adds the username and password parameters to the RestClient::Resrouce for the catalog_handler. This will allow conversion from lyberservices (non-authenticated) to dor-services-app (authenticated). 

This will require that services using the dor services catalog handler to add metadata.catalog.user and metadata.catalog.pass to the settings in shared_configs.