### PR TITLE
Always set an owner when building workflow processes

### DIFF
--- a/lib/dor/models/workflow_object.rb
+++ b/lib/dor/models/workflow_object.rb
@@ -33,6 +33,7 @@ module Dor
       @@repo_cache[name]
     end
 
+    # @return [Dor::WorkflowDefinitionDs]
     def definition
       datastreams['workflowDefinition']
     end

--- a/lib/dor/workflow/document.rb
+++ b/lib/dor/workflow/document.rb
@@ -40,6 +40,7 @@ module Workflow
       ng_xml.at_xpath('/workflow/process[not(@version)]') ? true : false
     end
 
+    # @return [Dor::WorkflowDefinitionDs]
     def definition
       @definition ||= begin
         if @@definitions.key? workflowId.first
@@ -71,14 +72,12 @@ module Workflow
       if definition
         definition.processes.collect do |process|
           node = ng_xml.at("/workflow/process[@name = '#{process.name}']")
-          process.update!(node, self) unless node.nil?
-          process
+          process.update!(node, self)
         end
       else
         find_by_terms(:workflow, :process).collect do |x|
           pnode = Dor::Workflow::Process.new(repository, workflowId, {})
           pnode.update!(x, self)
-          pnode
         end.sort_by(&:datetime)
       end
     end

--- a/lib/dor/workflow/process.rb
+++ b/lib/dor/workflow/process.rb
@@ -3,6 +3,9 @@ module Workflow
   class Process
     attr_reader :owner, :repo, :workflow
 
+    # @param repo [String] the name of the repository, typically 'dor'
+    # @param workflow [String] the name of the workflow, e.g. 'assemblyWF'
+    # @param attrs [Nokogiri::XML::Node, Hash]
     def initialize(repo, workflow, attrs)
       @workflow = workflow
       @repo = repo
@@ -82,14 +85,18 @@ module Workflow
       @attrs['elapsed'].nil? ? nil : @attrs['elapsed'].to_f
     end
 
-    # @param info [Nokogiri::XML::Element]
+    # Updates this object with the attributes passed in.
+    # @param info [Hash,Nokogiri::XML::Element,NilClass]
     # @param new_owner [Dor::Workflow::Document]
     def update!(info, new_owner)
       @owner = new_owner
+      return self if info.nil?
+
       if info.is_a? Nokogiri::XML::Node
         info = Hash[info.attributes.collect { |k, v| [k, v.value] }]
       end
       @attrs.merge! info
+      self
     end
 
     def to_hash

--- a/spec/models/workflow_document_spec.rb
+++ b/spec/models/workflow_document_spec.rb
@@ -1,50 +1,71 @@
 require 'spec_helper'
 
-describe Dor::Workflow::Document do
-
-  before(:each) do
+RSpec.describe Dor::Workflow::Document do
+  before do
     # stub the wf definition. The workflow document updates the processes in the definition with the values from the xml.
     @wf_definition = double(Dor::WorkflowObject)
     wf_definition_procs = []
-    wf_definition_procs << Dor::Workflow::Process.new('accessionWF', 'dor', {'name' => 'hello', 'lifecycle' => 'lc', 'status' => 'stat', 'sequence' => '1'})
-    wf_definition_procs << Dor::Workflow::Process.new('accessionWF', 'dor', {'name' => 'goodbye', 'status' => 'waiting', 'sequence' => '2'})
-    wf_definition_procs << Dor::Workflow::Process.new('accessionWF', 'dor', {'name' => 'technical-metadata', 'status' => 'error', 'sequence' => '3'})
+    wf_definition_procs << Dor::Workflow::Process.new('accessionWF', 'dor', {'name' => 'hello', 'lifecycle' => 'lc', 'status' => 'stat', 'sequence' => '1' })
+    wf_definition_procs << Dor::Workflow::Process.new('accessionWF', 'dor', {'name' => 'goodbye', 'status' => 'waiting', 'sequence' => '2', 'prerequisite' => ['hello'] })
+    wf_definition_procs << Dor::Workflow::Process.new('accessionWF', 'dor', {'name' => 'technical-metadata', 'status' => 'error', 'sequence' => '3' })
     wf_definition_procs << Dor::Workflow::Process.new('accessionWF', 'dor', {'name' => 'some-other-step', 'sequence' => '4'})
 
     allow(@wf_definition).to receive(:processes).and_return(wf_definition_procs)
   end
 
-  describe 'processes' do
-    it 'should generate an empty response from empty xml' do
-      xml = <<-eos
-      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-      <workflow objectId="druid:mf777zb0743" id="sdrIngestWF"/>
-      eos
-
-      # xml=Nokogiri::XML(xml)
-      d = Dor::Workflow::Document.new(xml)
-      allow(d).to receive(:definition).and_return(@wf_definition)
-      expect(d.processes.length).to eq(0)
+  describe '#processes' do
+    let(:document) { described_class.new(xml) }
+    subject(:processes) { document.processes }
+    before do
+      allow(document).to receive(:definition).and_return(@wf_definition)
     end
 
-    it 'should generate a process list based on the reified workflow which has sequence, not the processes list from the workflow service' do
-      xml = <<-eos
-      <?xml version="1.0" encoding="UTF-8"?>
-      <workflow repository="dor" objectId="druid:gv054hp4128" id="accessionWF">
-        <process version="2" lifecycle="submitted" elapsed="0.0" archived="true" attempts="1" datetime="2012-11-06T16:18:24-0800" status="completed" name="start-accession"/>
-        <process version="2" elapsed="0.0" archived="true" attempts="1" datetime="2012-11-06T16:18:58-0800" status="completed" name="technical-metadata"/>
-      </workflow>
-      eos
+    context 'when the xml is empty' do
+      let(:xml) do
+        <<-eos
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <workflow objectId="druid:mf777zb0743" id="sdrIngestWF"/>
+        eos
+      end
 
-      d = Dor::Workflow::Document.new(xml)
-      allow(d).to receive(:definition).and_return(@wf_definition)
-      expect(d.processes.length).to eq(4)
-      proc = d.processes.first
-      expect(proc.name).to eq('hello')
-      expect(proc.status).to eq('stat')
-      expect(proc.lifecycle).to eq('lc')
-      expect(proc.sequence).to eq('1')
+      it 'generates an empty response' do
+        expect(processes.length).to eq(0)
+      end
+    end
 
+    context 'when the xml contains a process list with a incomplete items' do
+      let(:xml) do
+        <<-eos
+        <?xml version="1.0" encoding="UTF-8"?>
+        <workflow repository="dor" objectId="druid:gv054hp4128" id="accessionWF">
+          <process version="2" lifecycle="submitted" elapsed="0.0" archived="true" attempts="1" datetime="2012-11-06T16:18:24-0800" status="inprogress" name="hello"/>
+        </workflow>
+        eos
+      end
+
+      it 'assigns an owner to each' do
+        expect(processes.map(&:owner)).to all(be_present)
+      end
+    end
+
+    context 'when the xml contains a process list with completed items' do
+      let(:xml) do
+        <<-eos
+        <?xml version="1.0" encoding="UTF-8"?>
+        <workflow repository="dor" objectId="druid:gv054hp4128" id="accessionWF">
+          <process version="2" lifecycle="submitted" elapsed="0.0" archived="true" attempts="1" datetime="2012-11-06T16:18:24-0800" status="completed" name="start-accession"/>
+          <process version="2" elapsed="0.0" archived="true" attempts="1" datetime="2012-11-06T16:18:58-0800" status="completed" name="technical-metadata"/>
+        </workflow>
+        eos
+      end
+      it 'generates a process list based on the reified workflow which has sequence, not the processes list from the workflow service' do
+        expect(processes.length).to eq(4)
+        proc = processes.first
+        expect(proc.name).to eq('hello')
+        expect(proc.status).to eq('stat')
+        expect(proc.lifecycle).to eq('lc')
+        expect(proc.sequence).to eq('1')
+      end
     end
   end
 
@@ -111,10 +132,14 @@ describe Dor::Workflow::Document do
     end
   end
 
-  describe 'to_solr' do
-
-    it 'should create the workflow_status field with the workflow repository included' do
-      xml = <<-eos
+  describe '#to_solr' do
+    let(:document) { described_class.new(xml) }
+    subject(:solr_doc) { document.to_solr }
+    before do
+      allow(document).to receive(:definition).and_return(@wf_definition)
+    end
+    let(:xml) do
+      <<-eos
       <?xml version="1.0" encoding="UTF-8"?>
       <workflow repository="dor" objectId="druid:gv054hp4128" id="accessionWF">
         <process version="2" lifecycle="submitted" elapsed="0.0" archived="true" attempts="1"
@@ -123,118 +148,134 @@ describe Dor::Workflow::Document do
          datetime="2012-11-06T16:18:58-0800" status="completed" name="technical-metadata"/>
       </workflow>
       eos
-
-      d = Dor::Workflow::Document.new(xml)
-      allow(d).to receive(:definition).and_return(@wf_definition)
-      doc = d.to_solr
-      expect(doc[Solrizer.solr_name('workflow_status', :symbol)].first).to eq('accessionWF|active|0|dor')
     end
 
-    it 'should index the right workflow status (completed) when all steps are completed or skipped' do
-      xml = <<-eos
-      <?xml version="1.0" encoding="UTF-8"?>
-      <workflow repository="dor" objectId="druid:gv054hp4128" id="accessionWF">
-        <process version="2" elapsed="0.0" archived="true" attempts="1"
-         datetime="2012-11-06T16:18:58-0800" status="skipped" name="hello"/>
-        <process version="2" lifecycle="submitted" elapsed="0.0" archived="true" attempts="1"
-         datetime="2012-11-06T16:18:24-0800" status="completed" name="start-accession"/>
-        <process version="2" elapsed="0.0" archived="true" attempts="1"
-         datetime="2012-11-06T16:18:58-0800" status="completed" name="technical-metadata"/>
-        <process version="2" elapsed="0.0" archived="true" attempts="1"
-         datetime="2012-11-06T16:18:58-0800" status="skipped" name="goodbye"/>
-      </workflow>
-      eos
-
-      d = Dor::Workflow::Document.new(xml)
-      allow(d).to receive(:definition).and_return(@wf_definition)
-      doc = d.to_solr
-      expect(doc).to match a_hash_including('workflow_status_ssim' => ['accessionWF|completed|0|dor'])
+    it 'creates the workflow_status field with the workflow repository included' do
+      expect(solr_doc[Solrizer.solr_name('workflow_status', :symbol)].first).to eq('accessionWF|active|0|dor')
     end
 
-    it 'should index the right workflow status (completed) when all steps have status of completed/skipped/nil/empty' do
-      xml = <<-eos
-      <?xml version="1.0" encoding="UTF-8"?>
-      <workflow repository="dor" objectId="druid:gv054hp4128" id="accessionWF">
-        <process version="2" elapsed="0.0" archived="true" attempts="1"
-         datetime="2012-11-06T16:18:58-0800" status="skipped" name="hello"/>
-        <process version="2" lifecycle="submitted" elapsed="0.0" archived="true" attempts="1"
-         datetime="2012-11-06T16:18:24-0800" status="completed" name="start-accession"/>
-        <process version="2" elapsed="0.0" archived="true" attempts="1"
-         datetime="2012-11-06T16:18:58-0800" status="completed" name="technical-metadata"/>
-        <process version="2" elapsed="0.0" archived="true" attempts="1"
-         datetime="2012-11-06T16:18:58-0800" status="" name="goodbye"/>
-      </workflow>
-      eos
+    context 'when the xml contains a process list with a waiting items that have a prerequisite' do
+      let(:xml) do
+        <<-eos
+        <?xml version="1.0" encoding="UTF-8"?>
+        <workflow repository="dor" objectId="druid:gv054hp4128" id="accessionWF">
+          <process version="2" lifecycle="submitted" elapsed="0.0" archived="true" attempts="1" datetime="2012-11-06T16:18:24-0800" status="inprogress" name="hello"/>
+        </workflow>
+        eos
+      end
 
-      d = Dor::Workflow::Document.new(xml)
-      allow(d).to receive(:definition).and_return(@wf_definition)
-      doc = d.to_solr
-      expect(doc).to match a_hash_including('workflow_status_ssim' => ['accessionWF|completed|0|dor'])
+      it 'indexes the right workflow status (active)' do
+        expect(solr_doc).to match a_hash_including('workflow_status_ssim' => ['accessionWF|active|1|dor'])
+      end
     end
 
-    it 'should index the iso8601 UTC dates for completed and errored workflow steps' do
-      xml = <<-eos
-      <?xml version="1.0" encoding="UTF-8"?>
-      <workflow repository="dor" objectId="druid:gv054hp4128" id="accessionWF">
-        <process version="2" elapsed="0.0" archived="true" attempts="1"
-         datetime="2012-11-06T16:18:57-0800" status="error" name="hello"/>
-        <process version="2" lifecycle="submitted" elapsed="0.0" archived="true" attempts="1"
-         datetime="2012-11-06T16:18:24-0800" status="completed" name="start-accession"/>
-        <process version="2" elapsed="0.0" archived="true" attempts="1"
-         datetime="2012-11-06T16:18:58-0800" status="completed" name="technical-metadata"/>
-        <process version="2" elapsed="0.0" archived="true" attempts="1"
-         datetime="2012-11-06T16:18:58-0800" status="" name="goodbye"/>
-      </workflow>
-      eos
-
-      d = Dor::Workflow::Document.new(xml)
-      allow(d).to receive(:definition).and_return(@wf_definition)
-      doc = d.to_solr
-
-      expect(doc).to match a_hash_including('wf_accessionWF_hello_dttsi' => '2012-11-07T00:18:57Z')
-      expect(doc).to match a_hash_including('wf_accessionWF_technical-metadata_dttsi' => '2012-11-07T00:18:58Z')
+    context 'when all steps are completed or skipped' do
+      let(:xml) do
+        <<-eos
+        <?xml version="1.0" encoding="UTF-8"?>
+        <workflow repository="dor" objectId="druid:gv054hp4128" id="accessionWF">
+          <process version="2" elapsed="0.0" archived="true" attempts="1"
+           datetime="2012-11-06T16:18:58-0800" status="skipped" name="hello"/>
+          <process version="2" lifecycle="submitted" elapsed="0.0" archived="true" attempts="1"
+           datetime="2012-11-06T16:18:24-0800" status="completed" name="start-accession"/>
+          <process version="2" elapsed="0.0" archived="true" attempts="1"
+           datetime="2012-11-06T16:18:58-0800" status="completed" name="technical-metadata"/>
+          <process version="2" elapsed="0.0" archived="true" attempts="1"
+           datetime="2012-11-06T16:18:58-0800" status="skipped" name="goodbye"/>
+        </workflow>
+        eos
+      end
+      it 'indexes the right workflow status (completed)' do
+        expect(solr_doc).to match a_hash_including('workflow_status_ssim' => ['accessionWF|completed|0|dor'])
+      end
     end
 
-    it 'should only index dates for completed and errored workflow steps which include a date' do
-      xml = <<-eos
-      <?xml version="1.0" encoding="UTF-8"?>
-      <workflow repository="dor" objectId="druid:gv054hp4128" id="accessionWF">
-        <process version="2" elapsed="0.0" archived="true" attempts="1"
-         datetime="" status="error" name="hello"/>
-        <process version="2" lifecycle="submitted" elapsed="0.0" archived="true" attempts="1"
-         datetime="2012-11-06T16:18:24-0800" status="completed" name="start-accession"/>
-        <process version="2" elapsed="0.0" archived="true" attempts="1"
-         datetime="2012-11-06T16:18:58-0800" status="completed" name="technical-metadata"/>
-        <process version="2" elapsed="0.0" archived="true" attempts="1"
-         datetime="2012-11-06T16:18:58-0800" status="" name="goodbye"/>
-      </workflow>
-      eos
-
-      d = Dor::Workflow::Document.new(xml)
-      allow(d).to receive(:definition).and_return(@wf_definition)
-      doc = d.to_solr
-
-      expect(doc).to match a_hash_including('wf_accessionWF_technical-metadata_dttsi')
-      expect(doc).not_to match a_hash_including('wf_accessionWF_hello_dttsi')
-      expect(doc).not_to match a_hash_including('wf_accessionWF_start-accession_dttsi')
-      expect(doc).not_to match a_hash_including('wf_accessionWF_goodbye_dttsi')
+    context 'when a step has an empty status' do
+      let(:xml) do
+        <<-eos
+        <?xml version="1.0" encoding="UTF-8"?>
+        <workflow repository="dor" objectId="druid:gv054hp4128" id="accessionWF">
+          <process version="2" elapsed="0.0" archived="true" attempts="1"
+           datetime="2012-11-06T16:18:58-0800" status="skipped" name="hello"/>
+          <process version="2" lifecycle="submitted" elapsed="0.0" archived="true" attempts="1"
+           datetime="2012-11-06T16:18:24-0800" status="completed" name="start-accession"/>
+          <process version="2" elapsed="0.0" archived="true" attempts="1"
+           datetime="2012-11-06T16:18:58-0800" status="completed" name="technical-metadata"/>
+          <process version="2" elapsed="0.0" archived="true" attempts="1"
+           datetime="2012-11-06T16:18:58-0800" status="" name="goodbye"/>
+        </workflow>
+        eos
+      end
+      it 'indexes the right workflow status (completed)' do
+        expect(solr_doc).to match a_hash_including('workflow_status_ssim' => ['accessionWF|completed|0|dor'])
+      end
     end
 
-    it 'should index error messages' do
-      xml = <<-eos
-      <?xml version="1.0" encoding="UTF-8"?>
-      <workflow repository="dor" objectId="druid:gv054hp4128" id="accessionWF">
-        <process version="2" lifecycle="submitted" elapsed="0.0" archived="true" attempts="1"
-         datetime="2012-11-06T16:18:24-0800" status="completed" name="start-accession"/>
-        <process version="2" elapsed="0.0" archived="true" attempts="1"
-         datetime="2012-11-06T16:18:58-0800" status="error" errorMessage="druid:gv054hp4128 - Item error; caused by 413 Request Entity Too Large:" name="technical-metadata"/>
-      </workflow>
-      eos
+    context 'when the xml has dates for completed and errored steps' do
+      let(:xml) do
+        <<-eos
+        <?xml version="1.0" encoding="UTF-8"?>
+        <workflow repository="dor" objectId="druid:gv054hp4128" id="accessionWF">
+          <process version="2" elapsed="0.0" archived="true" attempts="1"
+           datetime="2012-11-06T16:18:57-0800" status="error" name="hello"/>
+          <process version="2" lifecycle="submitted" elapsed="0.0" archived="true" attempts="1"
+           datetime="2012-11-06T16:18:24-0800" status="completed" name="start-accession"/>
+          <process version="2" elapsed="0.0" archived="true" attempts="1"
+           datetime="2012-11-06T16:18:58-0800" status="completed" name="technical-metadata"/>
+          <process version="2" elapsed="0.0" archived="true" attempts="1"
+           datetime="2012-11-06T16:18:58-0800" status="" name="goodbye"/>
+        </workflow>
+        eos
+      end
 
-      d = Dor::Workflow::Document.new(xml)
-      allow(d).to receive(:definition).and_return(@wf_definition)
-      doc = d.to_solr
-      expect(doc[Solrizer.solr_name('wf_error', :symbol)].first).to eq('accessionWF:technical-metadata:druid:gv054hp4128 - Item error; caused by 413 Request Entity Too Large:')
+      it 'indexes the iso8601 UTC dates' do
+        expect(solr_doc).to match a_hash_including('wf_accessionWF_hello_dttsi' => '2012-11-07T00:18:57Z')
+        expect(solr_doc).to match a_hash_including('wf_accessionWF_technical-metadata_dttsi' => '2012-11-07T00:18:58Z')
+      end
     end
+
+    context 'when the xml does not have dates for completed and errored steps' do
+      let(:xml) do
+        <<-eos
+        <?xml version="1.0" encoding="UTF-8"?>
+        <workflow repository="dor" objectId="druid:gv054hp4128" id="accessionWF">
+          <process version="2" elapsed="0.0" archived="true" attempts="1"
+           datetime="" status="error" name="hello"/>
+          <process version="2" lifecycle="submitted" elapsed="0.0" archived="true" attempts="1"
+           datetime="2012-11-06T16:18:24-0800" status="completed" name="start-accession"/>
+          <process version="2" elapsed="0.0" archived="true" attempts="1"
+           datetime="2012-11-06T16:18:58-0800" status="completed" name="technical-metadata"/>
+          <process version="2" elapsed="0.0" archived="true" attempts="1"
+           datetime="2012-11-06T16:18:58-0800" status="" name="goodbye"/>
+        </workflow>
+        eos
+      end
+
+      it 'only indexes the dates on steps that include a date' do
+        expect(solr_doc).to match a_hash_including('wf_accessionWF_technical-metadata_dttsi')
+        expect(solr_doc).not_to match a_hash_including('wf_accessionWF_hello_dttsi')
+        expect(solr_doc).not_to match a_hash_including('wf_accessionWF_start-accession_dttsi')
+        expect(solr_doc).not_to match a_hash_including('wf_accessionWF_goodbye_dttsi')
+      end
+    end
+
+    context 'when there are error messages' do
+      let(:xml) do
+        <<-eos
+        <?xml version="1.0" encoding="UTF-8"?>
+        <workflow repository="dor" objectId="druid:gv054hp4128" id="accessionWF">
+          <process version="2" lifecycle="submitted" elapsed="0.0" archived="true" attempts="1"
+           datetime="2012-11-06T16:18:24-0800" status="completed" name="start-accession"/>
+          <process version="2" elapsed="0.0" archived="true" attempts="1"
+           datetime="2012-11-06T16:18:58-0800" status="error" errorMessage="druid:gv054hp4128 - Item error; caused by 413 Request Entity Too Large:" name="technical-metadata"/>
+        </workflow>
+        eos
+      end
+
+      it 'indexes the error messages' do
+        expect(solr_doc[Solrizer.solr_name('wf_error', :symbol)].first).to eq('accessionWF:technical-metadata:druid:gv054hp4128 - Item error; caused by 413 Request Entity Too Large:')
+      end
+    end
+
   end
 end


### PR DESCRIPTION
The owner is required by the `ready?` and `blocked?` methods, which are called in indexing.

Ref https://github.com/sul-dlss/dor_indexing_app/issues/138