### PR TITLE
Move related_obj_display_title to the indexer

### DIFF
--- a/lib/dor/indexers/identifiable_indexer.rb
+++ b/lib/dor/indexers/identifiable_indexer.rb
@@ -48,6 +48,12 @@ module Dor
       end
     end
 
+    # Clears out the cache of items. Used primarily in testing.
+    def self.reset_cache!
+      @@collection_hash = {}
+      @@apo_hash = {}
+    end
+
     private
 
     def solrize_related_obj_titles(solr_doc, relationships, title_hash, union_field_name, nonhydrus_field_name, hydrus_field_name)
@@ -64,7 +70,7 @@ module Dor
         unless title_hash.key?(rel_druid)
           begin
             related_obj = Dor.find(rel_druid)
-            related_obj_title = get_related_obj_display_title(related_obj, rel_druid)
+            related_obj_title = related_obj_display_title(related_obj, rel_druid)
             is_from_hydrus = (related_obj&.tags&.include?('Project : Hydrus'))
             title_hash[rel_druid] = { 'related_obj_title' => related_obj_title, 'is_from_hydrus' => is_from_hydrus }
           rescue ActiveFedora::ObjectNotFoundError
@@ -81,6 +87,12 @@ module Dor
         end
         add_solr_value(solr_doc, union_field_name, title_hash[rel_druid]['related_obj_title'], title_type, title_attrs)
       end
+    end
+
+    def related_obj_display_title(related_obj, default_title)
+      return default_title unless related_obj
+
+      related_obj.full_title || default_title
     end
   end
 end

--- a/lib/dor/models/concerns/identifiable.rb
+++ b/lib/dor/models/concerns/identifiable.rb
@@ -180,12 +180,6 @@ module Dor
                       .any?
     end
 
-    def get_related_obj_display_title(related_obj, default_title)
-      return default_title unless related_obj
-
-      related_obj.full_title || default_title
-    end
-
     # a regex that can be used to identify the last part of a druid (e.g. oo000oo0001)
     # @return [Regex] a regular expression to identify the ID part of the druid
     def pid_regex

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Dor::Collection do

--- a/spec/models/concerns/identifiable_spec.rb
+++ b/spec/models/concerns/identifiable_spec.rb
@@ -285,27 +285,6 @@ describe Dor::Identifiable do
     end
   end
 
-  describe 'get_related_obj_display_title' do
-    it 'should return the descMetadata main title if it is available' do
-      mock_apo_title = 'apo title'
-      mock_apo_obj = double(Dor::AdminPolicyObject, full_title: mock_apo_title)
-
-      mock_default_title = 'druid:zy098xw7654'
-      expect(item.get_related_obj_display_title(mock_apo_obj, mock_default_title)).to eq(mock_apo_title)
-    end
-    it 'should return the default if the first descMetadata main title entry is empty string' do
-      mock_apo_obj = double(Dor::AdminPolicyObject, full_title: nil)
-
-      mock_default_title = 'druid:zy098xw7654'
-      expect(item.get_related_obj_display_title(mock_apo_obj, mock_default_title)).to eq(mock_default_title)
-    end
-    it 'should return the default if the related object is nil' do
-      mock_apo_obj = nil
-      mock_default_title = 'druid:zy098xw7654'
-      expect(item.get_related_obj_display_title(mock_apo_obj, mock_default_title)).to eq(mock_default_title)
-    end
-  end
-
   describe '#adapt_to_cmodel' do
     context 'for a Hydrus collection' do
       let(:item) { instantiate_fixture('druid:kq696sh3014', Dor::Abstract) }


### PR DESCRIPTION
This was referenced in this scope, but was not present.  Also added a test that covers the case where this method would be called.

This fixes a NoMethodError.

Fixes #383 