### PR TITLE
There is no need to assert_content_model in ActiveFedora 8.

### DIFF
--- a/lib/dor/indexers/identifiable_indexer.rb
+++ b/lib/dor/indexers/identifiable_indexer.rb
@@ -17,8 +17,6 @@ module Dor
     # @return [Hash] the partial solr document for identifiable concerns
     def to_solr
       solr_doc = {}
-      resource.assert_content_model
-
       solr_doc[Dor::INDEX_VERSION_FIELD] = Dor::VERSION
       solr_doc['indexed_at_dtsi'] = Time.now.utc.xmlschema
       resource.datastreams.values.each do |ds|

--- a/lib/dor/services/registration_service.rb
+++ b/lib/dor/services/registration_service.rb
@@ -132,8 +132,6 @@ module Dor
         Array(params[:seed_datastream]).each { |datastream_name| new_item.build_datastream(datastream_name) }
         Array(params[:initiate_workflow]).each { |workflow_id| new_item.create_workflow(workflow_id, !new_item.new_record?, workflow_priority) }
 
-        new_item.assert_content_model
-
         new_item.class.ancestors.select { |x| x.respond_to?(:to_class_uri) && x != ActiveFedora::Base }.each do |parent_class|
           new_item.add_relationship(:has_model, parent_class.to_class_uri)
         end


### PR DESCRIPTION
It already does it when you create a resource:
https://github.com/samvera/active_fedora/blob/release-8.x/lib/active_fedora/persistence.rb#L137