### PR TITLE
Deprecate Assembleable#initialize_workspace

### DIFF
--- a/lib/dor/models/concerns/assembleable.rb
+++ b/lib/dor/models/concerns/assembleable.rb
@@ -2,6 +2,9 @@
 
 module Dor
   module Assembleable
+    extend Deprecation
+    self.deprecation_horizon = 'dor-services version 7.0.0'
+
     def initialize_workspace(source = nil)
       druid = DruidTools::Druid.new(pid, Config.stacks.local_workspace_root)
       if source.nil?
@@ -10,5 +13,6 @@ module Dor
         druid.mkdir_with_final_link(source)
       end
     end
+    deprecation_deprecate initialize_workspace: 'This functionality has moved to dor_services_app'
   end
 end

--- a/spec/models/concerns/assembleable_spec.rb
+++ b/spec/models/concerns/assembleable_spec.rb
@@ -36,6 +36,7 @@ describe Dor::Assembleable do
       allow(@ai).to receive(:pid).and_return('aa123bb7890')
       @druid_path = File.join(@temp_workspace, 'aa', '123', 'bb', '7890', 'aa123bb7890')
       FileUtils.rm_rf(File.join(@temp_workspace, 'aa'))
+      expect(Deprecation).to receive(:warn)
     end
 
     it 'creates a plain directory in the workspace when passed no params' do


### PR DESCRIPTION
This functionality has been moved into dor-services-app

See https://github.com/sul-dlss/dor-services-app/pull/167