### PR TITLE
Deprecate list_file and get_file

### DIFF
--- a/lib/dor/models/concerns/contentable.rb
+++ b/lib/dor/models/concerns/contentable.rb
@@ -80,6 +80,7 @@ module Dor
       end
       data
     end
+    deprecation_deprecate get_file: 'use dor-services-app:/v1/objects/:id/contents/*path instead'
 
     # @param [String] filename
     def remove_file(filename)
@@ -148,6 +149,7 @@ module Dor
       end
       files
     end
+    deprecation_deprecate list_files: 'use dor-services-app:/v1/objects/:id/contents instead'
 
     # @param [String] filename
     # @return [Boolean] whether the file in question is present in the object's workspace

--- a/spec/models/concerns/contentable_spec.rb
+++ b/spec/models/concerns/contentable_spec.rb
@@ -141,6 +141,7 @@ describe Dor::Contentable do
     it 'should fetch the file' do
       data_file = File.new(File.join(fixture_dir, 'ab123cd4567_descMetadata.xml'))
       expect(@sftp).to receive(:download!).and_return(data_file.read)
+      expect(Deprecation).to receive(:warn)
       data = @item.get_file('ab123cd4567_descMetadata.xml')
       expect(Digest::MD5.hexdigest(data)).to eq('55251c7b93b3fbab83354f28e267f42f')
     end


### PR DESCRIPTION
These can be provided by an API in dor-services-app without the need to configure SFTP
credentials and hope that the server you are running from is permitted to connect.

Ref #399 
Ref #205