### PR TITLE
Allow collections to be preservable

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -159,6 +159,8 @@ Naming/MethodName:
     - 'lib/dor/models/concerns/preservable.rb'
     - 'lib/dor/models/concerns/releaseable.rb'
     - 'lib/dor/models/concerns/rightsable.rb'
+    - 'lib/dor/models/item.rb'
+
 
 # Offense count: 2
 # Configuration parameters: NamePrefix, NamePrefixBlacklist, NameWhitelist, MethodDefinitionMacros.

--- a/lib/dor/models/abstract.rb
+++ b/lib/dor/models/abstract.rb
@@ -9,6 +9,8 @@ module Dor
     include Describable
     include Versionable
     include Processable
+    include Preservable
+
     class_attribute :resource_indexer
 
     def to_solr

--- a/lib/dor/models/concerns/preservable.rb
+++ b/lib/dor/models/concerns/preservable.rb
@@ -6,7 +6,6 @@ module Dor
 
     included do
       has_metadata name: 'provenanceMetadata', type: ProvenanceMetadataDS, label: 'Provenance Metadata'
-      has_metadata name: 'technicalMetadata', type: TechnicalMetadataDS, label: 'Technical Metadata', control_group: 'M'
     end
 
     def build_provenanceMetadata_datastream(workflow_id, event_text)
@@ -15,10 +14,6 @@ module Dor
       ds.label ||= 'Provenance Metadata'
       ds.ng_xml = workflow_provenance
       ds.save
-    end
-
-    def build_technicalMetadata_datastream(_ds = nil)
-      TechnicalMetadataService.add_update_technical_metadata(self) if is_a?(Dor::Item) # only items need technical metadata, other object types do not have contentMetadata or content
     end
 
     def sdr_ingest_transfer(agreement_id)

--- a/lib/dor/models/item.rb
+++ b/lib/dor/models/item.rb
@@ -6,7 +6,6 @@ module Dor
     include Embargoable
     include Publishable
     include Itemizable
-    include Preservable
     include Assembleable
     include Contentable
     include Geoable
@@ -21,6 +20,12 @@ module Dor
       ProcessableIndexer,
       ReleasableIndexer
     )
+
+    has_metadata name: 'technicalMetadata', type: TechnicalMetadataDS, label: 'Technical Metadata', control_group: 'M'
+
+    def build_technicalMetadata_datastream(_ds = nil)
+      TechnicalMetadataService.add_update_technical_metadata(self)
+    end
   end
 end
 

--- a/spec/models/admin_policy_object_spec.rb
+++ b/spec/models/admin_policy_object_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe Dor::AdminPolicyObject do
   describe 'datastreams' do
     subject { described_class.ds_specs.keys }
     it do
-      is_expected.to eq ['RELS-EXT', 'DC', 'identityMetadata',
-                         'events', 'rightsMetadata', 'descMetadata', 'versionMetadata',
-                         'workflows', 'administrativeMetadata', 'roleMetadata',
-                         'defaultObjectRights']
+      is_expected.to match_array ['RELS-EXT', 'DC', 'identityMetadata',
+                                  'events', 'rightsMetadata', 'descMetadata', 'versionMetadata',
+                                  'workflows', 'administrativeMetadata', 'roleMetadata',
+                                  'defaultObjectRights', 'provenanceMetadata']
     end
   end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -3,6 +3,15 @@
 require 'spec_helper'
 
 RSpec.describe Dor::Collection do
+  describe '.datastreams' do
+    subject { described_class.ds_specs.keys }
+    it do
+      is_expected.to match_array ['RELS-EXT', 'DC', 'identityMetadata',
+                                  'events', 'rightsMetadata', 'descMetadata', 'versionMetadata',
+                                  'workflows', 'provenanceMetadata']
+    end
+  end
+
   describe '#to_solr' do
     subject(:doc) { collection.to_solr }
     let(:collection) { described_class.new(pid: 'foo:123') }

--- a/spec/models/concerns/preservable_spec.rb
+++ b/spec/models/concerns/preservable_spec.rb
@@ -48,18 +48,6 @@ describe Dor::Preservable do
     end
   end
 
-  it 'builds the technicalMetadata datastream if the object is an item' do
-    allow(item).to receive(:is_a?).with(Dor::Item).and_return(true)
-    expect(Dor::TechnicalMetadataService).to receive(:add_update_technical_metadata).with(item)
-    item.build_technicalMetadata_datastream('technicalMetadata')
-  end
-
-  it 'does not build the technicalMetadata datastream if the object is not an item' do
-    allow(item).to receive(:is_a?).with(Dor::Item).and_return(false)
-    expect(Dor::TechnicalMetadataService).not_to receive(:add_update_technical_metadata)
-    item.build_technicalMetadata_datastream('technicalMetadata')
-  end
-
   it 'exports object for sdr ingest' do
     expect(Dor::SdrIngestService).to receive(:transfer).with(item, nil)
     item.sdr_ingest_transfer(nil)

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -28,4 +28,13 @@ RSpec.describe Dor::Item do
       expect(workflows.mimeType).to eq 'application/xml'
     end
   end
+
+  describe '#build_technicalMetadata_datastream' do
+    let(:item) { described_class.new(pid: 'foo:123') }
+
+    it 'builds the technicalMetadata datastream if the object is an item' do
+      expect(Dor::TechnicalMetadataService).to receive(:add_update_technical_metadata).with(item)
+      item.build_technicalMetadata_datastream('technicalMetadata')
+    end
+  end
 end


### PR DESCRIPTION
This was lost in an attempt to ensure APOs didn't have technical metadata
 (see sul-dlss/hydrus#161, #353)

Now again make all objects Preservable, but move the techMetadata datastream just to Dor::Item as it is the only class of items that should have techMetadata.