### PR TITLE
ShelvingService#shelve must be public

### DIFF
--- a/lib/dor/services/shelving_service.rb
+++ b/lib/dor/services/shelving_service.rb
@@ -11,10 +11,6 @@ module Dor
       @work = work
     end
 
-    private
-
-    attr_reader :work
-
     def shelve
       # retrieve the differences between the current contentMetadata and the previously ingested version
       diff = shelve_diff
@@ -30,6 +26,10 @@ module Dor
       DigitalStacksService.rename_in_stacks(stacks_object_pathname, diff)
       DigitalStacksService.shelve_to_stacks(workspace_content_pathname, stacks_object_pathname, diff)
     end
+
+    private
+
+    attr_reader :work
 
     # retrieve the differences between the current contentMetadata and the previously ingested version
     # (filtering to select only the files that should be shelved to stacks)

--- a/spec/services/shelving_service_spec.rb
+++ b/spec/services/shelving_service_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Dor::ShelvingService do
     let(:mock_workspace_path) { double(Pathname) }
 
     before do
+      allow(described_class).to receive(:new).and_return(service)
       # stub the shelve_diff method which is unit tested below
       expect(service).to receive(:shelve_diff).and_return(mock_diff)
       # stub the workspace_content_dir method which is unit tested below
@@ -42,7 +43,7 @@ RSpec.describe Dor::ShelvingService do
       expect(Dor::DigitalStacksService).to receive(:remove_from_stacks).with(stacks_object_pathname, mock_diff)
       expect(Dor::DigitalStacksService).to receive(:rename_in_stacks).with(stacks_object_pathname, mock_diff)
       expect(Dor::DigitalStacksService).to receive(:shelve_to_stacks).with(mock_workspace_path, stacks_object_pathname, mock_diff)
-      service.send(:shelve)
+      described_class.shelve(work)
     end
   end
 


### PR DESCRIPTION
Othewise ShelvingService.shelve gets an error as it tries to call a private method