### PR TITLE
Add DublinCoreService#ng_xml

### DIFF
--- a/lib/dor/models/concerns/describable.rb
+++ b/lib/dor/models/concerns/describable.rb
@@ -43,11 +43,11 @@ module Dor
     # Generates Dublin Core from the MODS in the descMetadata datastream using the LoC mods2dc stylesheet
     #    Should not be used for the Fedora DC datastream
     # @raise [CrosswalkError] Raises an Exception if the generated DC is empty or has no children
-    # @return [Nokogiri::Doc] the DublinCore XML document object
+    # @return [Nokogiri::XML::Document] the DublinCore XML document object
     def generate_dublin_core(include_collection_as_related_item: true)
-      DublinCoreService.new(self, include_collection_as_related_item: include_collection_as_related_item).to_xml
+      DublinCoreService.new(self, include_collection_as_related_item: include_collection_as_related_item).ng_xml
     end
-    deprecation_deprecate generate_dublin_core: 'Use DublinCoreService#to_xml instead'
+    deprecation_deprecate generate_dublin_core: 'Use DublinCoreService#ng_xml instead'
 
     # @return [String] Public descriptive medatada XML
     def generate_public_desc_md(**options)

--- a/lib/dor/services/dublin_core_service.rb
+++ b/lib/dor/services/dublin_core_service.rb
@@ -14,14 +14,19 @@ module Dor
     # Generates Dublin Core from the MODS in the descMetadata datastream using the LoC mods2dc stylesheet
     #    Should not be used for the Fedora DC datastream
     # @raise [CrosswalkError] Raises an Exception if the generated DC is empty or has no children
-    # @return [Nokogiri::Doc] the DublinCore XML document object
-    def to_xml
+    # @return [Nokogiri::XML::Document] the DublinCore XML document object
+    def ng_xml
       dc_doc = MODS_TO_DC_XSLT.transform(desc_md)
       dc_doc.xpath('/oai_dc:dc/*[count(text()) = 0]', oai_dc: XMLNS_OAI_DC).remove # Remove empty nodes
       raise CrosswalkError, "Dor::Item#generate_dublin_core produced incorrect xml (no root):\n#{dc_doc.to_xml}" if dc_doc.root.nil?
       raise CrosswalkError, "Dor::Item#generate_dublin_core produced incorrect xml (no children):\n#{dc_doc.to_xml}" if dc_doc.root.children.size == 0
 
       dc_doc
+    end
+
+    # @return [String] the DublinCore XML document object
+    def to_xml
+      ng_xml.to_xml
     end
 
     private

--- a/lib/dor/services/public_xml_service.rb
+++ b/lib/dor/services/public_xml_service.rb
@@ -19,7 +19,7 @@ module Dor
       pub.add_child(public_rights_metadata.root)
 
       pub.add_child(public_relationships.root) unless public_relationships.nil? # TODO: Should never be nil in practice; working around an ActiveFedora quirk for testing
-      pub.add_child(object.generate_dublin_core.root)
+      pub.add_child(DublinCoreService.new(object).ng_xml.root)
       pub.add_child(PublicDescMetadataService.new(object).ng_xml.root)
       pub.add_child(release_xml.root) unless release_xml.xpath('//release').children.size == 0 # If there are no release_tags, this prevents an empty <releaseData/> from being added
       # Note we cannot base this on if an individual object has release tags or not, because the collection may cause one to be generated for an item,

--- a/lib/dor/services/publish_metadata_service.rb
+++ b/lib/dor/services/publish_metadata_service.rb
@@ -25,8 +25,7 @@ module Dor
     attr_reader :item
 
     def transfer_metadata
-      dc_xml = item.generate_dublin_core.to_xml(&:no_declaration)
-      transfer_to_document_store(dc_xml, 'dc')
+      transfer_to_document_store(DublinCoreService.new(item).ng_xml.to_xml(&:no_declaration), 'dc')
       %w(identityMetadata contentMetadata rightsMetadata).each do |stream|
         transfer_to_document_store(item.datastreams[stream].content.to_s, stream) if item.datastreams[stream]
       end

--- a/spec/models/concerns/describable_spec.rb
+++ b/spec/models/concerns/describable_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Dor::Describable do
 
   describe '#generate_dublin_core' do
     it 'delegates to the DublinCoreService' do
-      expect_any_instance_of(Dor::DublinCoreService).to receive(:to_xml)
+      expect_any_instance_of(Dor::DublinCoreService).to receive(:ng_xml)
       expect(Deprecation).to receive(:warn)
       @item.generate_dublin_core
     end

--- a/spec/services/dublin_core_service_spec.rb
+++ b/spec/services/dublin_core_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Dor::DublinCoreService do
 
   subject(:service) { described_class.new(item) }
 
-  describe '#to_xml' do
-    subject(:xml) { service.to_xml }
+  describe '#ng_xml' do
+    subject(:xml) { service.ng_xml }
 
     it 'produces dublin core from the MODS in the descMetadata datastream' do
       item.descMetadata.content = read_fixture('ex1_mods.xml')


### PR DESCRIPTION
This allows it to align with the other metaservices that have #ng_xml to
return the Nokogiri::XML::Document.

This also updates the PublishMetadata service to use DublinCoreService,
thus avoiding a deprecation