### PR TITLE
Pass an item to PublicDescMetadataService.new

### DIFF
--- a/dor-services.gemspec
+++ b/dor-services.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 4.2.10', '< 6.0.0'
   s.add_dependency 'confstruct', '~> 0.2.7'
   s.add_dependency 'deprecation', '~> 0'
-  s.add_dependency 'dor-services-client', '~> 0.4'
+  s.add_dependency 'dor-services-client', '~> 0.9'
   s.add_dependency 'equivalent-xml', '~> 0.5', '>= 0.5.1' # 5.0 insufficient
   s.add_dependency 'json', '>= 1.8.1'
   s.add_dependency 'net-sftp', '~> 2.1'

--- a/lib/dor/models/concerns/publishable.rb
+++ b/lib/dor/models/concerns/publishable.rb
@@ -69,7 +69,7 @@ module Dor
 
     # Call dor services app to have it publish the metadata
     def publish_metadata_remotely
-      Dor::Services::Client.publish(object: pid)
+      Dor::Services::Client.object(pid).publish
     end
     deprecation_deprecate publish_metadata_remotely: 'use Dor::Services::Client.publish instead'
   end

--- a/lib/dor/services/publish_metadata_service.rb
+++ b/lib/dor/services/publish_metadata_service.rb
@@ -30,7 +30,7 @@ module Dor
         transfer_to_document_store(item.datastreams[stream].content.to_s, stream) if item.datastreams[stream]
       end
       transfer_to_document_store(PublicXmlService.new(item).to_xml, 'public')
-      transfer_to_document_store(PublicDescMetadataService.new(self).to_xml, 'mods')
+      transfer_to_document_store(PublicDescMetadataService.new(item).to_xml, 'mods')
     end
 
     # Clear out the document cache for this item

--- a/spec/models/concerns/publishable_spec.rb
+++ b/spec/models/concerns/publishable_spec.rb
@@ -181,10 +181,12 @@ RSpec.describe Dor::Publishable do
     before do
       Dor::Config.push! { |config| config.dor_services.url 'https://lyberservices-test.stanford.edu/dor' }
       stub_request(:post, 'https://lyberservices-test.stanford.edu/dor/v1/objects/druid:ab123cd4567/publish')
+      allow(Deprecation).to receive(:warn)
     end
+
     it 'hits the correct url' do
-      expect(Deprecation).to receive(:warn)
       expect(item.publish_metadata_remotely).to be true
+      expect(Deprecation).to have_received(:warn)
     end
   end
 end


### PR DESCRIPTION
Previously we were passing an instance of PublishMetadataService.
This lead to a NoMethodError.
Fixes #471