### PR TITLE
Don't try to build datastreams that aren't declared

### DIFF
--- a/lib/dor/services/datastream_builder.rb
+++ b/lib/dor/services/datastream_builder.rb
@@ -22,10 +22,12 @@ module Dor
       @datastream = datastream
       @force = force
       @required = required
-      @filename = find_metadata_file
+      raise 'Datastream required, but none provided' if required && !datastream
     end
 
     def build
+      return unless datastream
+
       # See if datastream exists as a file and if the file's timestamp is newer than datastream's timestamp.
       if file_newer_than_datastream?
         create_from_file(filename)
@@ -38,7 +40,11 @@ module Dor
 
     private
 
-    attr_reader :datastream, :force, :object, :required, :filename
+    attr_reader :datastream, :force, :object, :required
+
+    def filename
+      @filename ||= find_metadata_file
+    end
 
     # @return [String] datastream name (dsid)
     def datastream_name

--- a/spec/services/datastream_builder_spec.rb
+++ b/spec/services/datastream_builder_spec.rb
@@ -9,9 +9,7 @@ RSpec.describe Dor::DatastreamBuilder do
     include Dor::Versionable
     include Dor::Describable
   end
-  before { item.contentMetadata.content = '<contentMetadata/>' }
 
-  let(:item) { instantiate_fixture('druid:ab123cd4567', ProcessableItem) }
   let(:required) { false }
   let(:dsid) { 'descMetadata' }
   subject(:builder) do
@@ -29,57 +27,71 @@ RSpec.describe Dor::DatastreamBuilder do
 
     subject(:build) { builder.build }
 
-    context 'when the datastream exists as a file' do
-      let(:time) { Time.now.utc }
-      before do
-        allow_any_instance_of(Dor::DatastreamBuilder).to receive(:find_metadata_file).and_return(dm_filename)
-        allow(File).to receive(:read).and_return(dm_fixture_xml)
-      end
+    describe 'when the item is a collection (and the datastream is nil)' do
+      let(:item) { Dor::Collection.new(pid: 'druid:bd185gs2256') }
+      let(:dsid) { 'contentMetadata' }
 
-      context 'when the file is newer than datastream' do
-        before do
-          allow(File).to receive(:mtime).and_return(time)
-          allow(item.descMetadata).to receive(:createDate).and_return(time - 99)
-        end
-
-        it 'reads content from file' do
-          expect { build }.to change { EquivalentXml.equivalent?(item.descMetadata.ng_xml, dm_fixture_xml) }
-            .from(false).to(true)
-        end
-      end
-
-      context 'when the file is older than datastream' do
-        before do
-          allow(File).to receive(:mtime).and_return(time - 99)
-          allow(item.descMetadata).to receive(:createDate).and_return(time)
-          allow(item).to receive(:fetch_descMetadata_datastream).and_return(dm_builder_xml)
-        end
-
-        it 'file older than datastream: should use the builder' do
-          expect { build }.to change { EquivalentXml.equivalent?(item.descMetadata.ng_xml, dm_builder_xml) }
-            .from(false).to(true)
-        end
+      it 'is a no-op' do
+        expect(build).to be_nil
       end
     end
 
-    context 'when the datastream does not exist as a file' do
-      before do
-        allow_any_instance_of(Dor::DatastreamBuilder).to receive(:find_metadata_file).and_return(nil)
-        allow(item).to receive(:fetch_descMetadata_datastream).and_return(dm_builder_xml)
+    context 'when operating on an Item' do
+      before { item.contentMetadata.content = '<contentMetadata/>' }
+      let(:item) { instantiate_fixture('druid:ab123cd4567', ProcessableItem) }
+
+      context 'when the datastream exists as a file' do
+        let(:time) { Time.now.utc }
+        before do
+          allow_any_instance_of(Dor::DatastreamBuilder).to receive(:find_metadata_file).and_return(dm_filename)
+          allow(File).to receive(:read).and_return(dm_fixture_xml)
+        end
+
+        context 'when the file is newer than datastream' do
+          before do
+            allow(File).to receive(:mtime).and_return(time)
+            allow(item.descMetadata).to receive(:createDate).and_return(time - 99)
+          end
+
+          it 'reads content from file' do
+            expect { build }.to change { EquivalentXml.equivalent?(item.descMetadata.ng_xml, dm_fixture_xml) }
+              .from(false).to(true)
+          end
+        end
+
+        context 'when the file is older than datastream' do
+          before do
+            allow(File).to receive(:mtime).and_return(time - 99)
+            allow(item.descMetadata).to receive(:createDate).and_return(time)
+            allow(item).to receive(:fetch_descMetadata_datastream).and_return(dm_builder_xml)
+          end
+
+          it 'file older than datastream: should use the builder' do
+            expect { build }.to change { EquivalentXml.equivalent?(item.descMetadata.ng_xml, dm_builder_xml) }
+              .from(false).to(true)
+          end
+        end
       end
 
-      it 'uses the datastream method builder' do
-        expect { build }.to change { EquivalentXml.equivalent?(item.descMetadata.ng_xml, dm_builder_xml) }
-          .from(false).to(true)
-      end
+      context 'when the datastream does not exist as a file' do
+        before do
+          allow_any_instance_of(Dor::DatastreamBuilder).to receive(:find_metadata_file).and_return(nil)
+          allow(item).to receive(:fetch_descMetadata_datastream).and_return(dm_builder_xml)
+        end
 
-      context 'when the datastream cannot be generated' do
-        let(:required) { true }
-        let(:dsid) { 'contentMetadata' }
+        it 'uses the datastream method builder' do
+          expect { build }.to change { EquivalentXml.equivalent?(item.descMetadata.ng_xml, dm_builder_xml) }
+            .from(false).to(true)
+        end
 
-        it 'raises an exception' do
-          # Fails because there is no build_contentMetadata_datastream() method.
-          expect { build }.to raise_error(RuntimeError)
+        context 'when the datastream cannot be generated' do
+          let(:required) { true }
+          let(:dsid) { 'contentMetadata' }
+
+          it 'raises an exception' do
+            # Fails because there is no build_contentMetadata_datastream() method.
+            expect { build }.to raise_error(RuntimeError)
+          end
         end
       end
     end


### PR DESCRIPTION
The old way was working because Collection objects didn't respond to `build__datastream` https://github.com/sul-dlss/dor-services/blob/v5.32.1/lib/dor/models/concerns/processable.rb#L86-L87