### PR TITLE
Restore Releasable#release_tags

### DIFF
--- a/lib/dor/models/concerns/releaseable.rb
+++ b/lib/dor/models/concerns/releaseable.rb
@@ -35,6 +35,11 @@ module Dor
       releases.released_for(skip_live_purl: skip_live_purl)
     end
 
+    # Helper method to get the release tags as a nodeset
+    # @return [Nokogiri::XML::NodeSet] all release tags and their attributes
+    delegate :release_tags, to: :releases
+    deprecation_deprecate release_tags: 'use ReleaseTagService#release_tags instead'
+
     def releases
       @releases ||= ReleaseTagService.for(self)
     end

--- a/lib/dor/services/release_tag_service.rb
+++ b/lib/dor/services/release_tag_service.rb
@@ -20,7 +20,7 @@ module Dor
       released_hash = {}
 
       # Get the most recent self tag for all targets and retain their result since most recent self always trumps any other non self tags
-      latest_self_tags = newest_release_tag self_release_tags(release_nodes)
+      latest_self_tags = newest_release_tag self_release_tags(release_tags)
       latest_self_tags.each do |key, payload|
         released_hash[key] = { 'release' => payload['release'] }
       end
@@ -48,7 +48,7 @@ module Dor
     # Take an item and get all of its release tags and all tags on collections it is a member of it
     # @return [Hash] a hash of all tags
     def release_tags_for_item_and_all_governing_sets
-      return_tags = release_nodes || {}
+      return_tags = release_tags || {}
       item.collections.each do |collection|
         next if collection.id == item.id # recursive, so parents of parents are found, but we need to avoid an infinite loop if the collection references itself (i.e. bad data)
 
@@ -57,11 +57,9 @@ module Dor
       return_tags
     end
 
-    private
-
-    # Helper method to get the release nodes as a nodeset
-    # @return [Nokogiri::XML::NodeSet] of all release tags and their attributes
-    def release_nodes
+    # Helper method to get the release tags as a nodeset
+    # @return [Nokogiri::XML::NodeSet] all release tags and their attributes
+    def release_tags
       release_tags = item.identityMetadata.ng_xml.xpath('//release')
       return_hash = {}
       release_tags.each do |release_tag|
@@ -75,21 +73,7 @@ module Dor
       return_hash
     end
 
-    # Helper method to get the release tags as a nodeset
-    # @return [Nokogiri::XML::NodeSet] all release tags and their attributes
-    def release_tags
-      release_tags = identityMetadata.ng_xml.xpath('//release')
-      return_hash = {}
-      release_tags.each do |release_tag|
-        hashed_node = release_tag_node_to_hash(release_tag)
-        if !return_hash[hashed_node[:to]].nil?
-          return_hash[hashed_node[:to]] << hashed_node[:attrs]
-        else
-          return_hash[hashed_node[:to]] = [hashed_node[:attrs]]
-        end
-      end
-      return_hash
-    end
+    private
 
     # Convert one release element into a Hash
     # @param rtag [Nokogiri::XML::Element] the release tag element

--- a/spec/services/release_tag_service_spec.rb
+++ b/spec/services/release_tag_service_spec.rb
@@ -111,32 +111,36 @@ RSpec.describe Dor::ReleaseTagService, :vcr do
     end
   end
 
-  describe '#release_nodes' do
-    subject(:release_nodes) { releases.send(:release_nodes) }
+  describe '#release_tags' do
+    subject(:release_tags) { releases.release_tags }
 
-    context 'for an item that does not have any release nodes' do
+    context 'for an item that does not have any release tags' do
       let(:item) { instantiate_fixture('druid:qv648vd4392', Dor::Item) }
 
       it { is_expected.to eq({}) }
     end
 
     it 'returns the releases for an item that has release tags' do
-      exp_result = { 'Revs' => [
-        { 'tag' => 'true', 'what' => 'collection', 'when' => Time.parse('2015-01-06 23:33:47Z'), 'who' => 'carrickr', 'release' => true },
-        { 'tag' => 'true', 'what' => 'self', 'when' => Time.parse('2015-01-06 23:33:54Z'), 'who' => 'carrickr', 'release' => true },
-        { 'tag' => 'Project : Fitch : Batch2', 'what' => 'self', 'when' => Time.parse('2015-01-06 23:40:01Z'), 'who' => 'carrickr', 'release' => false }
-      ] }
-      expect(release_nodes).to eq exp_result
+      exp_result = {
+        'Revs' => [
+          { 'tag' => 'true', 'what' => 'collection', 'when' => Time.parse('2015-01-06 23:33:47Z'), 'who' => 'carrickr', 'release' => true },
+          { 'tag' => 'true', 'what' => 'self', 'when' => Time.parse('2015-01-06 23:33:54Z'), 'who' => 'carrickr', 'release' => true },
+          { 'tag' => 'Project : Fitch : Batch2', 'what' => 'self', 'when' => Time.parse('2015-01-06 23:40:01Z'), 'who' => 'carrickr', 'release' => false }
+        ]
+      }
+      expect(release_tags).to eq exp_result
     end
   end
 
-  it 'returns a hash created from a single release tag' do
-    n = Nokogiri('<release to="Revs" what="collection" when="2015-01-06T23:33:47Z" who="carrickr">true</release>').xpath('//release')[0]
-    exp_result = { to: 'Revs', attrs: { 'what' => 'collection', 'when' => Time.parse('2015-01-06 23:33:47Z'), 'who' => 'carrickr', 'release' => true } }
-    expect(releases.send(:release_tag_node_to_hash, n)).to eq exp_result
-    n = Nokogiri('<release tag="Project : Fitch: Batch1" to="Revs" what="collection" when="2015-01-06T23:33:47Z" who="carrickr">true</release>').xpath('//release')[0]
-    exp_result = { to: 'Revs', attrs: { 'tag' => 'Project : Fitch: Batch1', 'what' => 'collection', 'when' => Time.parse('2015-01-06 23:33:47Z'), 'who' => 'carrickr', 'release' => true } }
-    expect(releases.send(:release_tag_node_to_hash, n)).to eq exp_result
+  describe '#release_tag_node_to_hash' do
+    it 'returns a hash created from a single release tag' do
+      n = Nokogiri('<release to="Revs" what="collection" when="2015-01-06T23:33:47Z" who="carrickr">true</release>').xpath('//release')[0]
+      exp_result = { to: 'Revs', attrs: { 'what' => 'collection', 'when' => Time.parse('2015-01-06 23:33:47Z'), 'who' => 'carrickr', 'release' => true } }
+      expect(releases.send(:release_tag_node_to_hash, n)).to eq exp_result
+      n = Nokogiri('<release tag="Project : Fitch: Batch1" to="Revs" what="collection" when="2015-01-06T23:33:47Z" who="carrickr">true</release>').xpath('//release')[0]
+      exp_result = { to: 'Revs', attrs: { 'tag' => 'Project : Fitch: Batch1', 'what' => 'collection', 'when' => Time.parse('2015-01-06 23:33:47Z'), 'who' => 'carrickr', 'release' => true } }
+      expect(releases.send(:release_tag_node_to_hash, n)).to eq exp_result
+    end
   end
 
   describe '#form_purl_url' do


### PR DESCRIPTION
This was accidentally made private without deprecation.
Restore it's public visibility and deprecate it.

Removed release_nodes as it was identical to release_tags.

Ref https://github.com/sul-dlss/item-release/issues/120