### PR TITLE
Restore Releasable#get_newest_release_tag

### DIFF
--- a/lib/dor/models/concerns/releaseable.rb
+++ b/lib/dor/models/concerns/releaseable.rb
@@ -40,6 +40,14 @@ module Dor
     delegate :release_tags, to: :releases
     deprecation_deprecate release_tags: 'use ReleaseTagService#release_tags instead'
 
+    # Take a hash of tags as obtained via Dor::Item.release_tags and returns the newest tag for each namespace
+    # @param tags [Hash] a hash of tags obtained via Dor::Item.release_tags or matching format
+    # @return [Hash] a hash of latest tags for each to value
+    def get_newest_release_tag(tags)
+      releases.newest_release_tag(tags)
+    end
+    deprecation_deprecate get_newest_release_tag: 'use ReleaseTagService#newest_release_tag instead'
+
     def releases
       @releases ||= ReleaseTagService.for(self)
     end

--- a/lib/dor/services/release_tag_service.rb
+++ b/lib/dor/services/release_tag_service.rb
@@ -73,6 +73,13 @@ module Dor
       return_hash
     end
 
+    # Take a hash of tags as obtained via Dor::Item.release_tags and returns the newest tag for each namespace
+    # @param tags [Hash] a hash of tags obtained via Dor::Item.release_tags or matching format
+    # @return [Hash] a hash of latest tags for each to value
+    def newest_release_tag(tags)
+      Hash[tags.map { |key, val| [key, newest_release_tag_in_an_array(val)] }]
+    end
+
     private
 
     # Convert one release element into a Hash
@@ -127,13 +134,6 @@ module Dor
         hash_one[key] = (hash_one[key] + hash_two[key]).uniq unless hash_one[key].nil?
       end
       hash_one
-    end
-
-    # Take a hash of tags as obtained via Dor::Item.release_tags and returns the newest tag for each namespace
-    # @param tags [Hash] a hash of tags obtained via Dor::Item.release_tags or matching format
-    # @return [Hash] a hash of latest tags for each to value
-    def newest_release_tag(tags)
-      Hash[tags.map { |key, val| [key, newest_release_tag_in_an_array(val)] }]
     end
 
     # Takes an array of release tags and returns the most recent one

--- a/spec/models/concerns/releaseable_spec.rb
+++ b/spec/models/concerns/releaseable_spec.rb
@@ -146,6 +146,20 @@ RSpec.describe 'Adding release nodes', :vcr do
     end
   end
 
+  describe '#get_newest_release_tag' do
+    subject(:get_newest_release_tag) { item.get_newest_release_tag('Revs' => %w[foo bar], 'FRDA' => %w[quax qwerk]) }
+    let(:service) { instance_double(Dor::ReleaseTagService, newest_release_tag: { 'Revs' => 'foo', 'FRDA' => 'qwerk' }) }
+
+    before do
+      allow(Dor::ReleaseTagService).to receive(:for).with(item).and_return(service)
+    end
+
+    it 'delegates to the service' do
+      expect(Deprecation).to receive(:warn)
+      expect(get_newest_release_tag).to eq('FRDA' => 'qwerk', 'Revs' => 'foo')
+    end
+  end
+
   describe 'Adding tags and workflows' do
     before do
       expect(Deprecation).to receive(:warn)

--- a/spec/services/release_tag_service_spec.rb
+++ b/spec/services/release_tag_service_spec.rb
@@ -24,11 +24,13 @@ RSpec.describe Dor::ReleaseTagService, :vcr do
     describe '#newest_release_tag_in_an_array' do
       subject { releases.send(:newest_release_tag_in_an_array, dummy_tags) }
       it { is_expected.to eq dummy_tags[1] }
+    end
 
-      it 'returns the latest tag for each key/target in a hash' do
-        dummy_hash = { 'Revs' => dummy_tags, 'FRDA' => dummy_tags }
-        expect(releases.send(:newest_release_tag, dummy_hash)).to eq('Revs' => dummy_tags[1], 'FRDA' => dummy_tags[1])
-      end
+    describe '#newest_release_tag' do
+      subject { releases.newest_release_tag(dummy_hash) }
+      let(:dummy_hash) { { 'Revs' => dummy_tags, 'FRDA' => dummy_tags } }
+
+      it { is_expected.to eq('Revs' => dummy_tags[1], 'FRDA' => dummy_tags[1]) }
     end
 
     describe '#latest_applicable_release_tag_in_array' do


### PR DESCRIPTION
it was accidentally removed in
https://github.com/sul-dlss/dor-services/commit/cdccf45c772a41f829f0b90435f95d49cf175953#diff-7ed0ee62a290e26677f1bfe60b66fd33
but it is used by item-release