### PR TITLE
Require dor-workflow-service explicitly

### DIFF
--- a/lib/dor-services.rb
+++ b/lib/dor-services.rb
@@ -180,7 +180,6 @@ module Dor
     autoload :TechnicalMetadataService
     autoload :ThumbnailService
     autoload :VersionService
-    autoload :WorkflowService
   end
 
   # Workflow Classes
@@ -193,4 +192,5 @@ module Dor
   eager_load!
 
   require 'dor/utils/hydrus_shims'
+  require 'dor-workflow-service'
 end


### PR DESCRIPTION
Previously it was attempting to autoload a constant that was defined
in another gem. This seems dodgy.