### PR TITLE
Create a custom error when there is a problem contacting the catalog

### DIFF
--- a/lib/dor/exceptions.rb
+++ b/lib/dor/exceptions.rb
@@ -11,6 +11,9 @@ module Dor
   # rubocop:disable Lint/InheritException
   # See https://github.com/rubocop-hq/rubocop/issues/6770
   class VersionAlreadyOpenError < Exception; end
+
+  # Raised when we can't get a response from the catalog
+  class BadResponseFromCatalog < Exception; end
   # rubocop:enable Lint/InheritException
 
   class DuplicateIdError < RuntimeError

--- a/lib/dor/services/metadata_handlers/catalog_handler.rb
+++ b/lib/dor/services/metadata_handlers/catalog_handler.rb
@@ -7,7 +7,10 @@ handler = Class.new do
     client = RestClient::Resource.new(Dor::Config.metadata.catalog.url,
                                       Dor::Config.metadata.catalog.user,
                                       Dor::Config.metadata.catalog.pass)
-    client["?#{prefix.chomp}=#{identifier.chomp}"].get
+    params = "?#{prefix.chomp}=#{identifier.chomp}"
+    client[params].get
+  rescue RestClient::Exception => e
+    raise BadResponseFromCatalog, "#{e.class} - when contacting (with BasicAuth hidden): #{Dor::Config.metadata.catalog.url}#{params}"
   end
 
   def label(metadata)


### PR DESCRIPTION
Hopefully this makes it easier to see where the problem is as this
message gets logged in the workflow service