### PR TITLE
Deprecate risearch

### DIFF
--- a/lib/dor/services/search_service.rb
+++ b/lib/dor/services/search_service.rb
@@ -5,6 +5,7 @@ require 'active_support/core_ext'
 
 module Dor
   class SearchService
+    extend Deprecation
     RISEARCH_TEMPLATE = "select $object from <#ri> where $object <dc:identifier> '%s'"
     @@index_version = nil
 
@@ -13,7 +14,9 @@ module Dor
         Dor::VERSION
       end
 
+      # @deprecated because this depends on Fedora 3 having sparql turned on
       def risearch(query, opts = {})
+        Deprecation.warn(self, 'risearch is deprecated and will be removed in dor-services 7')
         client = Config.fedora.client['risearch']
         client.options[:timeout] = opts.delete(:timeout)
         query_params = {
@@ -28,7 +31,9 @@ module Dor
         result.split(/\n/)[1..-1].collect { |pid| pid.chomp.sub(/^info:fedora\//, '') }
       end
 
+      # @deprecated because this depends on Fedora 3 having sparql turned on
       def iterate_over_pids(opts = {})
+        Deprecation.warn(self, 'iterate_over_pids is deprecated and will be removed in dor-services 7')
         opts[:query] ||= 'select $object from <#ri> where $object <info:fedora/fedora-system:def/model#label> $label'
         opts[:in_groups_of] ||= 100
         opts[:mode] ||= :single

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -13,6 +13,7 @@ describe Dor::SearchService do
 
   context '.risearch' do
     before do
+      allow(Deprecation).to receive(:warn)
       @druids = [
         ['druid:rk464yc0651', 'druid:xx122nh4588', 'druid:mj151qw9093', 'druid:mn144df7801', 'druid:rx565mb6270'],
         ['druid:tx361mw6047', 'druid:cm977wg2520', 'druid:tk695fn1971', 'druid:jk486qb3656', 'druid:cd252xn6059'], []
@@ -31,6 +32,7 @@ describe Dor::SearchService do
       expect(resp).to eq(@druids[0])
       resp = described_class.risearch(query, limit: 5, offset: 5)
       expect(resp).to eq(@druids[1])
+      expect(Deprecation).to have_received(:warn).twice
     end
 
     it 'iterates over pids in groups' do
@@ -38,12 +40,14 @@ describe Dor::SearchService do
       expect(receiver).to receive(:process).with(@druids[0])
       expect(receiver).to receive(:process).with(@druids[1])
       described_class.iterate_over_pids(in_groups_of: 5, mode: :group) { |x| receiver.process(x) }
+      expect(Deprecation).to have_received(:warn).exactly(4).times
     end
 
     it 'iterates over pids one at a time' do
       receiver = double('block')
       @druids.flatten.each { |druid| expect(receiver).to receive(:process).with(druid) }
       described_class.iterate_over_pids(in_groups_of: 5, mode: :single) { |x| receiver.process(x) }
+      expect(Deprecation).to have_received(:warn).exactly(4).times
     end
   end
 


### PR DESCRIPTION
This is not useful because it requires the risearch to work dependably
which it does not.  See https://github.com/sul-dlss/argo/issues/380

Fixes #523 