### PR TITLE
Unroll get_collection_title

### DIFF
--- a/lib/dor/models/concerns/describable.rb
+++ b/lib/dor/models/concerns/describable.rb
@@ -38,10 +38,6 @@ module Dor
       descMetadata.content = builder.to_xml
     end
 
-    def self.get_collection_title(obj)
-      obj.full_title
-    end
-
     def full_title
       stanford_mods.sw_title_display
     end

--- a/lib/dor/services/public_desc_metadata_service.rb
+++ b/lib/dor/services/public_desc_metadata_service.rb
@@ -96,7 +96,7 @@ module Dor
         # load the title from the parent's DC.title
         titleInfo = doc.create_element 'titleInfo'
         title = doc.create_element 'title'
-        title.content = Dor::Describable.get_collection_title(parent_item)
+        title.content = parent_item.full_title
         titleInfo << title
         relatedItem << titleInfo
 
@@ -144,7 +144,7 @@ module Dor
       end
 
       title_node         = Nokogiri::XML::Node.new('title', doc)
-      title_node.content = Dor::Describable.get_collection_title(collection_obj)
+      title_node.content = collection_obj.full_title
 
       title_info_node = Nokogiri::XML::Node.new('titleInfo', doc)
       title_info_node.add_child(title_node)

--- a/spec/models/concerns/describable_spec.rb
+++ b/spec/models/concerns/describable_spec.rb
@@ -28,37 +28,6 @@ RSpec.describe Dor::Describable do
     expect(@item.datastreams['descMetadata']).to be_a(Dor::DescMetadataDS)
   end
 
-  describe 'get_collection_title' do
-    before do
-      @item = instantiate_fixture('druid:ab123cd4567', Dor::Item)
-    end
-
-    it 'gets a titleInfo/title' do
-      @item.descMetadata.content = <<-XML
-      <?xml version="1.0"?>
-      <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd">
-      <titleInfo>
-      <title>Foxml Test Object</title>
-      </titleInfo>
-      </mods>
-      XML
-      expect(described_class.get_collection_title(@item)).to eq 'Foxml Test Object'
-    end
-
-    it 'includes a subtitle if there is one' do
-      @item.descMetadata.content = <<-XML
-      <?xml version="1.0"?>
-      <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd">
-      <titleInfo>
-      <title>Foxml Test Object</title>
-      <subTitle>Hello world</note>
-      </titleInfo>
-      </mods>
-      XML
-      expect(described_class.get_collection_title(@item)).to eq 'Foxml Test Object : Hello world'
-    end
-  end
-
   describe 'set_desc_metadata_using_label' do
     it 'creates basic mods using the object label' do
       allow(@obj.datastreams['descMetadata']).to receive(:content).and_return ''


### PR DESCRIPTION
It's easier to understand without this indirection