### PR TITLE
Remove WorkflowObject.initial_workflow and initial_repo

### DIFF
--- a/lib/dor/datastreams/workflow_definition_ds.rb
+++ b/lib/dor/datastreams/workflow_definition_ds.rb
@@ -53,28 +53,6 @@ module Dor
       ng_xml.at_xpath('/workflow-def/@repository').to_s
     end
 
-    # Creates the xml used by Dor::Workflow::Client#create_workflow
-    # @return [String] An object's initial workflow as defined by the <workflow-def> in content
-    def initial_workflow
-      doc = Nokogiri::XML('<workflow/>')
-      root = doc.root
-      root['id'] = name
-      processes.each do |proc|
-        doc.create_element 'process' do |node|
-          node['name'] = proc.name
-          if proc.status
-            node['status'] = proc.status
-            node['attempts'] = '1'
-          else
-            node['status'] = 'waiting'
-          end
-          node['lifecycle'] = proc.lifecycle if proc.lifecycle
-          root.add_child node
-        end
-      end
-      Nokogiri::XML(doc.to_xml, &:noblanks).to_xml(&:no_declaration)
-    end
-
     def to_solr(solr_doc = {}, *args)
       solr_doc = super(solr_doc, *args)
       add_solr_value(solr_doc, 'workflow_name', name, :symbol, [:symbol])

--- a/lib/dor/models/workflow_object.rb
+++ b/lib/dor/models/workflow_object.rb
@@ -4,9 +4,6 @@ require 'dor/datastreams/workflow_definition_ds'
 
 module Dor
   class WorkflowObject < Dor::Abstract
-    @@xml_cache  = {}
-    @@repo_cache = {}
-
     has_object_type 'workflow'
     has_metadata name: 'workflowDefinition', type: Dor::WorkflowDefinitionDs, label: 'Workflow Definition'
 
@@ -22,50 +19,9 @@ module Dor
       Dor::WorkflowObject.where(Solrizer.solr_name('workflow_name', :symbol) => name).first
     end
 
-    # Searches for the workflow definition object in DOR, then
-    # returns an object's initial workflow as defined in the worfklowDefinition datastream
-    # It will cache the result for subsequent requests
-    # @param [String] name the name of the workflow
-    # @return [String] the initial workflow xml
-    def self.initial_workflow(name)
-      return @@xml_cache[name] if @@xml_cache.include?(name)
-
-      find_and_cache_workflow_xml_and_repo name
-      @@xml_cache[name]
-    end
-
-    # Returns the repository attribute from the workflow definition
-    # It will cache the result for subsequent requests
-    # @param [String] name the name of the workflow
-    # @return [String] the initial workflow xml
-    def self.initial_repo(name)
-      return @@repo_cache[name] if @@repo_cache.include?(name)
-
-      find_and_cache_workflow_xml_and_repo name
-      @@repo_cache[name]
-    end
-
     # @return [Dor::WorkflowDefinitionDs]
     def definition
       datastreams['workflowDefinition']
-    end
-
-    def generate_initial_workflow
-      datastreams['workflowDefinition'].initial_workflow
-    end
-
-    alias generate_intial_workflow generate_initial_workflow
-
-    # Searches DOR for the workflow definition object.  It then caches the workflow repository and xml
-    # @param [String] name the name of the workflow
-    # @return [Object] a Dor::xxxx object, e.g. a Dor::Item object
-    def self.find_and_cache_workflow_xml_and_repo(name)
-      wobj = find_by_name(name)
-      raise "Failed to find workflow via find_by_name('#{name}')" if wobj.nil?
-
-      @@repo_cache[name] = wobj.definition.repo
-      @@xml_cache[name]  = wobj.generate_initial_workflow
-      wobj
     end
   end
 end

--- a/spec/datastreams/workflow_definition_ds_spec.rb
+++ b/spec/datastreams/workflow_definition_ds_spec.rb
@@ -28,17 +28,4 @@ describe Dor::WorkflowDefinitionDs do
       expect(ds.name).to eq('accessionWF')
     end
   end
-
-  describe '#initial_workflow' do
-    it 'creates workflow xml from the definition in its content' do
-      expected = <<-EOXML
-        <workflow id="accessionWF">
-           <process name="start-accession" status="completed" lifecycle="submitted" attempts="1"/>
-           <process name="content-metadata" status="waiting"/>
-           <process name="descriptive-metadata" status="waiting" lifecycle="described"/>
-        </workflow>
-      EOXML
-      expect(ds.initial_workflow).to be_equivalent_to(expected)
-    end
-  end
 end

--- a/spec/models/workflow_object_spec.rb
+++ b/spec/models/workflow_object_spec.rb
@@ -2,19 +2,7 @@
 
 require 'spec_helper'
 
-describe Dor::WorkflowObject do
-  describe '.initial_workflow' do
-    it 'caches the intial workflow xml for subsequent requests' do
-      wobj = double('workflow_object').as_null_object
-      expect(described_class).to receive(:find_by_name).once.and_return(wobj)
-
-      # First call, object not in cache
-      described_class.initial_workflow('accessionWF')
-      # Second call, object in cache
-      expect(described_class.initial_workflow('accessionWF')).to eq(wobj)
-    end
-  end
-
+RSpec.describe Dor::WorkflowObject do
   # TODO: Move to the DataIndexer spec
   describe '#to_solr' do
     let(:wf_indexer) { instance_double(Dor::WorkflowsIndexer, to_solr: {}) }


### PR DESCRIPTION
This is all taken care of by workflow-servier-rails now.
This was deprecated in https://github.com/sul-dlss/dor-services/pull/622