### PR TITLE
Fix copypasta of workflow status indexing

### DIFF
--- a/lib/dor/indexers/workflow_indexer.rb
+++ b/lib/dor/indexers/workflow_indexer.rb
@@ -45,7 +45,7 @@ module Dor
       index_error_message(solr_doc, wf_name, process)
 
       # workflow name, process status then process name
-      solr_doc.add_wps("#{wf_name}:#{process.status}", "#{wf_name}:#{process.status}:#{process.name}")
+      solr_doc.add_wsp("#{wf_name}:#{process.status}", "#{wf_name}:#{process.status}:#{process.name}")
 
       # workflow name, process name then process status
       solr_doc.add_wps("#{wf_name}:#{process.name}", "#{wf_name}:#{process.name}:#{process.status}")


### PR DESCRIPTION
We're currently combining WPS and WSP values in Argo's `Workflow (WPS)` facet:

<img width="255" alt="Screen Shot 2019-06-06 at 11 12 39" src="https://user-images.githubusercontent.com/111218/59055989-025c3480-884c-11e9-8d58-9fa99b859c04.png">

This looks like a copypasta error during some recent refactoring.