### PR TITLE
fix status computation when a lifecycle completes with same timestamp for last steps

### DIFF
--- a/lib/dor/services/status_service.rb
+++ b/lib/dor/services/status_service.rb
@@ -48,11 +48,11 @@ module Dor
     def status_info
       status_code = 0
       status_time = nil
-      # for each milestone in the current version, see if it comes after the current 'last' step, if so, make it the last and record the date/time
+      # for each milestone in the current version, see if it comes at the same time or after the current 'last' step, if so, make it the last and record the date/time
       current_milestones.each do |m|
         m_name = m[:milestone]
         m_time = m[:at].utc.xmlschema
-        next unless STEPS.key?(m_name) && (!status_time || m_time > status_time)
+        next unless STEPS.key?(m_name) && (!status_time || m_time >= status_time)
 
         status_code = STEPS[m_name]
         status_time = m_time

--- a/spec/services/status_service_spec.rb
+++ b/spec/services/status_service_spec.rb
@@ -88,5 +88,56 @@ RSpec.describe Dor::StatusService do
         expect(described_class.status(item, true)).to eq('v2 Accessioned 2013-10-01 07:11PM')
       end
     end
+
+    context 'for an accessioned step with the exact same timestamp as the deposited step' do
+      let(:xml) do
+        Nokogiri::XML('<?xml version="1.0"?>
+        <lifecycle objectId="druid:bd504dj1946">
+        <milestone date="2013-04-03T15:01:57-0700">registered</milestone>
+        <milestone date="2013-04-03T16:20:19-0700">digitized</milestone>
+        <milestone date="2013-04-16T14:18:20-0700" version="1">submitted</milestone>
+        <milestone date="2013-04-16T14:32:54-0700" version="1">described</milestone>
+        <milestone date="2013-04-16T14:55:10-0700" version="1">published</milestone>
+        <milestone date="2013-07-21T05:27:23-0700" version="1">deposited</milestone>
+        <milestone date="2013-07-21T05:28:09-0700" version="1">accessioned</milestone>
+        <milestone date="2013-08-15T11:59:16-0700" version="2">opened</milestone>
+        <milestone date="2013-10-01T12:01:07-0700" version="2">submitted</milestone>
+        <milestone date="2013-10-01T12:01:24-0700" version="2">described</milestone>
+        <milestone date="2013-10-01T12:05:38-0700" version="2">published</milestone>
+        <milestone date="2013-10-01T12:10:56-0700" version="2">deposited</milestone>
+        <milestone date="2013-10-01T12:10:56-0700" version="2">accessioned</milestone>
+        </lifecycle>')
+      end
+
+      it 'has the correct status of accessioned (v2) object' do
+        expect(versionMD).to receive(:current_version_id).and_return('2')
+        expect(described_class.status(item, true)).to eq('v2 Accessioned 2013-10-01 07:10PM')
+      end
+    end
+
+    context 'for a deposited step for a non-accessioned object' do
+      let(:xml) do
+        Nokogiri::XML('<?xml version="1.0"?>
+        <lifecycle objectId="druid:bd504dj1946">
+        <milestone date="2013-04-03T15:01:57-0700">registered</milestone>
+        <milestone date="2013-04-03T16:20:19-0700">digitized</milestone>
+        <milestone date="2013-04-16T14:18:20-0700" version="1">submitted</milestone>
+        <milestone date="2013-04-16T14:32:54-0700" version="1">described</milestone>
+        <milestone date="2013-04-16T14:55:10-0700" version="1">published</milestone>
+        <milestone date="2013-07-21T05:27:23-0700" version="1">deposited</milestone>
+        <milestone date="2013-07-21T05:28:09-0700" version="1">accessioned</milestone>
+        <milestone date="2013-08-15T11:59:16-0700" version="2">opened</milestone>
+        <milestone date="2013-10-01T12:01:07-0700" version="2">submitted</milestone>
+        <milestone date="2013-10-01T12:01:24-0700" version="2">described</milestone>
+        <milestone date="2013-10-01T12:05:38-0700" version="2">published</milestone>
+        <milestone date="2013-10-01T12:10:56-0700" version="2">deposited</milestone>
+        </lifecycle>')
+      end
+
+      it 'has the correct status of deposited (v2) object' do
+        expect(versionMD).to receive(:current_version_id).and_return('2')
+        expect(described_class.status(item, true)).to eq('v2 In accessioning (described, published, deposited) 2013-10-01 07:10PM')
+      end
+    end
   end
 end


### PR DESCRIPTION
fixes #642 