### PR TITLE
show the object as accessioned if it has an accesioned milestone

### DIFF
--- a/lib/dor/services/status_service.rb
+++ b/lib/dor/services/status_service.rb
@@ -46,6 +46,10 @@ module Dor
 
     # @return [Hash{Symbol => Object}] including :current_version, :status_code and :status_time
     def status_info
+      # if we have an accessioned milestone, this is the last possible step and should be the status regardless of time stamp
+      accessioned_milestones = current_milestones.select { |m| m[:milestone] == 'accessioned' }
+      return { current_version: current_version, status_code: STEPS['accessioned'], status_time: accessioned_milestones.last[:at].utc.xmlschema } unless accessioned_milestones.empty?
+
       status_code = 0
       status_time = nil
       # for each milestone in the current version, see if it comes at the same time or after the current 'last' step, if so, make it the last and record the date/time

--- a/spec/services/status_service_spec.rb
+++ b/spec/services/status_service_spec.rb
@@ -115,6 +115,32 @@ RSpec.describe Dor::StatusService do
       end
     end
 
+    context 'for an accessioned step with an ealier timestamp than the deposited step' do
+      let(:xml) do
+        Nokogiri::XML('<?xml version="1.0"?>
+        <lifecycle objectId="druid:bd504dj1946">
+        <milestone date="2013-04-03T15:01:57-0700">registered</milestone>
+        <milestone date="2013-04-03T16:20:19-0700">digitized</milestone>
+        <milestone date="2013-04-16T14:18:20-0700" version="1">submitted</milestone>
+        <milestone date="2013-04-16T14:32:54-0700" version="1">described</milestone>
+        <milestone date="2013-04-16T14:55:10-0700" version="1">published</milestone>
+        <milestone date="2013-07-21T05:27:23-0700" version="1">deposited</milestone>
+        <milestone date="2013-07-21T05:28:09-0700" version="1">accessioned</milestone>
+        <milestone date="2013-08-15T11:59:16-0700" version="2">opened</milestone>
+        <milestone date="2013-10-01T12:01:07-0700" version="2">submitted</milestone>
+        <milestone date="2013-10-01T12:01:24-0700" version="2">described</milestone>
+        <milestone date="2013-10-01T12:05:38-0700" version="2">published</milestone>
+        <milestone date="2013-10-01T12:10:56-0700" version="2">deposited</milestone>
+        <milestone date="2013-09-01T12:10:56-0700" version="2">accessioned</milestone>
+        </lifecycle>')
+      end
+
+      it 'has the correct status of accessioned (v2) object' do
+        expect(versionMD).to receive(:current_version_id).and_return('2')
+        expect(described_class.status(item, true)).to eq('v2 Accessioned 2013-09-01 07:10PM')
+      end
+    end
+
     context 'for a deposited step for a non-accessioned object' do
       let(:xml) do
         Nokogiri::XML('<?xml version="1.0"?>


### PR DESCRIPTION
...even if it is not the last timestamp

This gets around the issue where we show a status to users in Argo that is incorrect if an earlier workflow step with an earlier lifecycle is manually repeated or triggered during an object remediation.  The idea is that if an object has a current lifecycle of accessioned (current being the latest version), it should be considered accessioned regardless of timestamps.
