### PR TITLE
content_metadata_ds.add_virtual_resource: allow parent to have no existing resources (7-2-stable branch)

### DIFF
--- a/lib/dor/datastreams/content_metadata_ds.rb
+++ b/lib/dor/datastreams/content_metadata_ds.rb
@@ -174,7 +174,7 @@ module Dor
     def add_virtual_resource(child_druid, child_resource)
       # create a virtual resource element with attributes linked to the child and omit label
       ng_xml_will_change!
-      sequence_max = ng_xml.search('//resource').map { |node| node[:sequence].to_i }.max
+      sequence_max = ng_xml.search('//resource').map { |node| node[:sequence].to_i }.max || 0
       resource = Nokogiri::XML::Element.new('resource', ng_xml)
       resource[:sequence] = sequence_max + 1
       resource[:id] = "#{pid.gsub(/^druid:/, '')}_#{resource[:sequence]}"


### PR DESCRIPTION
Connects to #651 

add_virtual_resource was failing because the parent contentMetadata had no resources;  this allows it to start with 0 resources (e.g. when the --purge flag is set for virtual-merge script in dor-utils)

argo uses v7 of the gem, so this will allow us to leverage this fix when we move the virtual merge script to argo.