### PR TITLE
Deprecate configuration item local_document_cache_root

### DIFF
--- a/lib/dor/static_config/stacks_config.rb
+++ b/lib/dor/static_config/stacks_config.rb
@@ -4,6 +4,9 @@ module Dor
   class StaticConfig
     # Represents the configuration for the shared filesystem direcotories
     class StacksConfig
+      extend Deprecation
+      self.deprecation_horizon = 'dor-services 9.0'
+
       def initialize(hash)
         @document_cache_host = hash.fetch(:document_cache_host)
         @local_stacks_root = hash.fetch(:local_stacks_root)
@@ -34,6 +37,7 @@ module Dor
         @local_document_cache_root = new_value if new_value
         @local_document_cache_root
       end
+      deprecation_deprecate :local_document_cache_root
     end
   end
 end


### PR DESCRIPTION
it's only used by dor-services-app