### PR TITLE
Update StateService to take a version

### DIFF
--- a/dor-services.gemspec
+++ b/dor-services.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
 
   # Stanford dependencies
   s.add_dependency 'dor-rights-auth', '~> 1.0', '>= 1.2.0'
-  s.add_dependency 'dor-workflow-client', '~> 3.3'
+  s.add_dependency 'dor-workflow-client', '~> 3.8'
   s.add_dependency 'druid-tools', '>= 0.4.1'
   s.add_dependency 'stanford-mods', '>= 2.3.1'
   s.add_dependency 'stanford-mods-normalizer', '~> 0.1'


### PR DESCRIPTION
This ensures the workflow-service doesn't have to make a request to dor-services-app for the version

Fixes #662 