### PR TITLE
Revert part of 0f93ec0ce20f666bcc2e8d29c94bf813229053a8

### DIFF
--- a/lib/dor/services/state_service.rb
+++ b/lib/dor/services/state_service.rb
@@ -13,7 +13,7 @@ module Dor
 
     def allows_modification?
       !client.lifecycle('dor', pid, 'submitted') ||
-        client.lifecycle('dor', pid, 'opened', version: version) ||
+        client.active_lifecycle('dor', pid, 'opened') ||
         client.workflow_status('dor', pid, 'accessionWF', 'sdr-ingest-transfer') == 'hold'
     end
 

--- a/spec/services/state_services_spec.rb
+++ b/spec/services/state_services_spec.rb
@@ -30,26 +30,28 @@ RSpec.describe Dor::StateService do
 
       context 'if there is an open version' do
         before do
-          allow(Dor::Config.workflow.client).to receive(:lifecycle).and_return(true, true)
+          allow(Dor::Config.workflow.client).to receive(:lifecycle).and_return(true)
+          allow(Dor::Config.workflow.client).to receive(:active_lifecycle).and_return(true)
         end
 
         it 'returns true' do
           expect(allows_modification?).to be true
           expect(Dor::Config.workflow.client).to have_received(:lifecycle).with('dor', 'ab12cd3456', 'submitted')
-          expect(Dor::Config.workflow.client).to have_received(:lifecycle).with('dor', 'ab12cd3456', 'opened', version: 4)
+          expect(Dor::Config.workflow.client).to have_received(:active_lifecycle).with('dor', 'ab12cd3456', 'opened')
         end
       end
 
       context 'when the item has sdr-ingest-transfer set to hold' do
         before do
-          allow(Dor::Config.workflow.client).to receive(:lifecycle).and_return(true, false)
+          allow(Dor::Config.workflow.client).to receive(:lifecycle).and_return(true)
+          allow(Dor::Config.workflow.client).to receive(:active_lifecycle).and_return(false)
           allow(Dor::Config.workflow.client).to receive(:workflow_status).and_return('hold')
         end
 
         it 'returns true' do
           expect(allows_modification?).to be true
           expect(Dor::Config.workflow.client).to have_received(:lifecycle).with('dor', 'ab12cd3456', 'submitted')
-          expect(Dor::Config.workflow.client).to have_received(:lifecycle).with('dor', 'ab12cd3456', 'opened', version: 4)
+          expect(Dor::Config.workflow.client).to have_received(:active_lifecycle).with('dor', 'ab12cd3456', 'opened')
         end
       end
     end
@@ -70,26 +72,28 @@ RSpec.describe Dor::StateService do
 
       context 'if there is an open version' do
         before do
-          allow(Dor::Config.workflow.client).to receive(:lifecycle).and_return(true, true)
+          allow(Dor::Config.workflow.client).to receive(:lifecycle).and_return(true)
+          allow(Dor::Config.workflow.client).to receive(:active_lifecycle).and_return(true)
         end
 
         it 'returns true' do
           expect(allows_modification?).to be true
           expect(Dor::Config.workflow.client).to have_received(:lifecycle).with('dor', 'ab12cd3456', 'submitted')
-          expect(Dor::Config.workflow.client).to have_received(:lifecycle).with('dor', 'ab12cd3456', 'opened', version: 3)
+          expect(Dor::Config.workflow.client).to have_received(:active_lifecycle).with('dor', 'ab12cd3456', 'opened')
         end
       end
 
       context 'when the item has sdr-ingest-transfer set to hold' do
         before do
-          allow(Dor::Config.workflow.client).to receive(:lifecycle).and_return(true, false)
+          allow(Dor::Config.workflow.client).to receive(:lifecycle).and_return(true)
+          allow(Dor::Config.workflow.client).to receive(:active_lifecycle).and_return(false)
           allow(Dor::Config.workflow.client).to receive(:workflow_status).and_return('hold')
         end
 
         it 'returns true' do
           expect(allows_modification?).to be true
           expect(Dor::Config.workflow.client).to have_received(:lifecycle).with('dor', 'ab12cd3456', 'submitted')
-          expect(Dor::Config.workflow.client).to have_received(:lifecycle).with('dor', 'ab12cd3456', 'opened', version: 3)
+          expect(Dor::Config.workflow.client).to have_received(:active_lifecycle).with('dor', 'ab12cd3456', 'opened')
         end
       end
     end


### PR DESCRIPTION
This was causing versions to not be openable

Ref https://github.com/sul-dlss/argo/issues/1654