### PR TITLE
Pass the version to the active_version workflow call

### DIFF
--- a/dor-services.gemspec
+++ b/dor-services.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
 
   # Stanford dependencies
   s.add_dependency 'dor-rights-auth', '~> 1.0', '>= 1.2.0'
-  s.add_dependency 'dor-workflow-client', '~> 3.8'
+  s.add_dependency 'dor-workflow-client', '~> 3.9'
   s.add_dependency 'druid-tools', '>= 0.4.1'
   s.add_dependency 'stanford-mods', '>= 2.3.1'
   s.add_dependency 'stanford-mods-normalizer', '~> 0.1'

--- a/lib/dor/services/state_service.rb
+++ b/lib/dor/services/state_service.rb
@@ -13,7 +13,7 @@ module Dor
 
     def allows_modification?
       !client.lifecycle('dor', pid, 'submitted') ||
-        client.active_lifecycle('dor', pid, 'opened') ||
+        client.active_lifecycle('dor', pid, 'opened', version: version) ||
         client.workflow_status('dor', pid, 'accessionWF', 'sdr-ingest-transfer') == 'hold'
     end
 

--- a/spec/services/state_services_spec.rb
+++ b/spec/services/state_services_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Dor::StateService do
         it 'returns true' do
           expect(allows_modification?).to be true
           expect(Dor::Config.workflow.client).to have_received(:lifecycle).with('dor', 'ab12cd3456', 'submitted')
-          expect(Dor::Config.workflow.client).to have_received(:active_lifecycle).with('dor', 'ab12cd3456', 'opened')
+          expect(Dor::Config.workflow.client).to have_received(:active_lifecycle).with('dor', 'ab12cd3456', 'opened', version: 4)
         end
       end
 
@@ -51,7 +51,7 @@ RSpec.describe Dor::StateService do
         it 'returns true' do
           expect(allows_modification?).to be true
           expect(Dor::Config.workflow.client).to have_received(:lifecycle).with('dor', 'ab12cd3456', 'submitted')
-          expect(Dor::Config.workflow.client).to have_received(:active_lifecycle).with('dor', 'ab12cd3456', 'opened')
+          expect(Dor::Config.workflow.client).to have_received(:active_lifecycle).with('dor', 'ab12cd3456', 'opened', version: 4)
         end
       end
     end
@@ -79,7 +79,7 @@ RSpec.describe Dor::StateService do
         it 'returns true' do
           expect(allows_modification?).to be true
           expect(Dor::Config.workflow.client).to have_received(:lifecycle).with('dor', 'ab12cd3456', 'submitted')
-          expect(Dor::Config.workflow.client).to have_received(:active_lifecycle).with('dor', 'ab12cd3456', 'opened')
+          expect(Dor::Config.workflow.client).to have_received(:active_lifecycle).with('dor', 'ab12cd3456', 'opened', version: 3)
         end
       end
 
@@ -93,7 +93,7 @@ RSpec.describe Dor::StateService do
         it 'returns true' do
           expect(allows_modification?).to be true
           expect(Dor::Config.workflow.client).to have_received(:lifecycle).with('dor', 'ab12cd3456', 'submitted')
-          expect(Dor::Config.workflow.client).to have_received(:active_lifecycle).with('dor', 'ab12cd3456', 'opened')
+          expect(Dor::Config.workflow.client).to have_received(:active_lifecycle).with('dor', 'ab12cd3456', 'opened', version: 3)
         end
       end
     end


### PR DESCRIPTION
If you don't pass a version the workflow service will make a HTTP request to dor-services-app to get the version. This makes it very slow to open/close versions.