### PR TITLE
Reduce indirection by passing a url rather than a symbol

### DIFF
--- a/lib/dor/rest_resource_factory.rb
+++ b/lib/dor/rest_resource_factory.rb
@@ -5,33 +5,19 @@ module Dor
   class RestResourceFactory
     include Singleton
 
-    # @param type [Symbol] the type of connection to create (e.g. :fedora)
+    # @param url [String] the url to connect to
     # @return [RestClient::Resource]
-    def self.create(type)
-      instance.create(type)
+    def self.create(url)
+      instance.create(url)
     end
 
-    # @param type [Symbol] the type of connection to create (e.g. :fedora)
+    # @param url [String] the url to connect to
     # @return [RestClient::Resource]
-    def create(type)
-      RestClient::Resource.new(url_for(type), connection_options)
+    def create(url)
+      RestClient::Resource.new(url, connection_options)
     end
 
     private
-
-    # @param type [Symbol] the type of connection to create (e.g. :fedora)
-    # @return [String] the url to connect to.
-    def url_for(type)
-      connection_configuration(type).url
-    end
-
-    # @param type [Symbol] the type of connection to create (e.g. :fedora)
-    # @return [#url] the configuration for the connection
-    def connection_configuration(type)
-      Dor::Config.fetch(type)
-    rescue KeyError
-      raise "ERROR: Unable to find a configuration for #{type}"
-    end
 
     # @return [Hash] options for creating a RestClient::Resource
     def connection_options

--- a/lib/dor/static_config/fedora_config.rb
+++ b/lib/dor/static_config/fedora_config.rb
@@ -15,7 +15,7 @@ module Dor
       end
 
       def client
-        CertificateAuthenticatedRestResourceFactory.create(:fedora)
+        CertificateAuthenticatedRestResourceFactory.create(url)
       end
 
       def url(new_value = nil)


### PR DESCRIPTION
This fixes a problem where `Dor::Config.fetch` was not defined.  With this change, we no longer need to call that.