### PR TITLE
When indexing workflows use the templates in workflow-service-app

### DIFF
--- a/lib/dor/datastreams/workflow_definition_ds.rb
+++ b/lib/dor/datastreams/workflow_definition_ds.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Dor
+  # @deprecated
   class WorkflowDefinitionDs < ActiveFedora::OmDatastream
     include SolrDocHelper
 

--- a/lib/dor/indexers/workflows_indexer.rb
+++ b/lib/dor/indexers/workflows_indexer.rb
@@ -12,7 +12,7 @@ module Dor
     def to_solr
       WorkflowSolrDocument.new do |combined_doc|
         workflows.each do |wf|
-          doc = WorkflowIndexer.new(document: wf).to_solr
+          doc = WorkflowIndexer.new(workflow: wf).to_solr
           combined_doc.merge!(doc)
         end
       end.to_h
@@ -20,15 +20,15 @@ module Dor
 
     private
 
-    # @return [Array<Dor::Workflow::Document>]
+    # @return [Array<Workflow::Response::Workflow>]
     def workflows
-      # TODO: this could use the models in dor-workflow-service: https://github.com/sul-dlss/dor-workflow-client/pull/101
-      nodeset = Nokogiri::XML(all_workflows_xml).xpath('/workflows/workflow')
-      nodeset.map { |wf_node| Workflow::Document.new wf_node.to_xml }
+      all_workflows.workflows
     end
 
-    def all_workflows_xml
-      @all_workflows_xml ||= Dor::Config.workflow.client.all_workflows_xml resource.pid
+    # TODO: remove Dor::Workflow::Document
+    # @return [Workflow::Response::Workflows]
+    def all_workflows
+      @all_workflows ||= Dor::Config.workflow.client.workflow_routes.all_workflows pid: resource.pid
     end
   end
 end

--- a/lib/dor/models/workflow_object.rb
+++ b/lib/dor/models/workflow_object.rb
@@ -3,6 +3,7 @@
 require 'dor/datastreams/workflow_definition_ds'
 
 module Dor
+  # @deprecated
   class WorkflowObject < Dor::Abstract
     has_object_type 'workflow'
     has_metadata name: 'workflowDefinition', type: Dor::WorkflowDefinitionDs, label: 'Workflow Definition'

--- a/lib/dor/workflow/document.rb
+++ b/lib/dor/workflow/document.rb
@@ -23,6 +23,7 @@ module Dor
       @@definitions = {}
 
       def initialize(node)
+        Deprecation.warn(self, 'Dor::Workflow::Document is deprecated and will be removed from dor-services version 9')
         self.ng_xml = Nokogiri::XML(node)
       end
 

--- a/lib/dor/workflow/process.rb
+++ b/lib/dor/workflow/process.rb
@@ -9,6 +9,7 @@ module Dor
       # @param workflow [String] the name of the workflow, e.g. 'assemblyWF'
       # @param attrs [Nokogiri::XML::Node, Hash]
       def initialize(repo, workflow, attrs)
+        Deprecation.warn(self, 'Dor::Workflow::Process is deprecated and will be removed from dor-services version 9')
         @workflow = workflow
         @repo = repo
         if attrs.is_a? Nokogiri::XML::Node

--- a/spec/models/workflow_document_spec.rb
+++ b/spec/models/workflow_document_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Dor::Workflow::Document do
   let(:stub_wfo) { instance_double(Dor::WorkflowObject, definition: wf_definition) }
 
   before do
+    allow(Deprecation).to receive(:warn)
     # Wipe out the cache
     described_class.class_variable_set(:@@definitions, {})
     allow(Dor::WorkflowObject).to receive(:find_by_name).and_return(stub_wfo)


### PR DESCRIPTION
The old method was using the templates from Fedora, which are not being kept up to date.

Ref sul-dlss/argo#1757