### PR TITLE
Send a notification if there are missing release tags

### DIFF
--- a/lib/dor/release_tags/identity_metadata.rb
+++ b/lib/dor/release_tags/identity_metadata.rb
@@ -181,6 +181,8 @@ module Dor
       # @return [Hash] same form as new_tags, with all missing tags not in new_tags, but in current_tag_names, added in with a Boolean value of false
       def add_tags_from_purl(new_tags)
         missing_tags = release_tags_from_purl.map(&:downcase) - new_tags.keys.map(&:downcase)
+        Honeybadger.notify("Found missing release tags on PURL for #{pid}: #{missing_tags.inspect}") if missing_tags.present? && defined? Honeybadger
+
         missing_tags.each do |missing_tag|
           new_tags[missing_tag.capitalize] = { 'release' => false }
         end


### PR DESCRIPTION
This should never happen and we should consider removing this code path.


This was added in https://github.com/sul-dlss/dor-services/commit/439b8084f5f36567bbefeb954f40ebee82268ff1

Proposed for removal in https://github.com/sul-dlss/dor-services-app/issues/630