### PR TITLE
Declare model properties that are used by registration

### DIFF
--- a/lib/dor/datastreams/identity_metadata_ds.rb
+++ b/lib/dor/datastreams/identity_metadata_ds.rb
@@ -70,7 +70,7 @@ module Dor
     alias source_id= sourceId=
 
     def tags
-      ng_xml.search('//tag').collect(&:content)
+      tag
     end
 
     # helper method to get just the content type tag
@@ -86,6 +86,11 @@ module Dor
       else
         result.select { |n| n['name'] == type }.collect(&:text)
       end
+    end
+
+    # @param [Array<String>] values
+    def other_ids=(values)
+      values.each { |value| add_otherId(value) }
     end
 
     def add_otherId(other_id)

--- a/lib/dor/models/abstract.rb
+++ b/lib/dor/models/abstract.rb
@@ -118,7 +118,11 @@ module Dor
 
     delegate :full_title, :stanford_mods, to: :descMetadata
     delegate :rights, to: :rightsMetadata
-    delegate :catkey, :catkey=, :previous_catkeys, :tags, :content_type_tag, :source_id, :source_id=, to: :identityMetadata
+    delegate :catkey, :catkey=, :source_id, :source_id=,
+             :objectId, :objectId=, :objectCreator, :objectCreator=,
+             :objectLabel, :objectLabel=, :objectType, :objectType=,
+             :other_ids=, :otherId, :tag=, :tags,
+             :previous_catkeys, :content_type_tag, to: :identityMetadata
 
     def read_rights=(rights)
       rightsMetadata.set_read_rights(rights)

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -348,6 +348,60 @@ RSpec.describe Dor::Item do
     end
   end
 
+  describe '#objectId=' do
+    let(:item) { described_class.new }
+
+    it 'is settable and gettable' do
+      item.objectId = 'foo'
+      expect(item.objectId).to eq 'foo'
+    end
+  end
+
+  describe '#objectCreator=' do
+    let(:item) { described_class.new }
+
+    it 'is settable and gettable' do
+      item.objectCreator = 'foo'
+      expect(item.objectCreator).to eq ['foo']
+    end
+  end
+
+  describe '#objectLabel=' do
+    let(:item) { described_class.new }
+
+    it 'is settable and gettable' do
+      item.objectLabel = 'foo'
+      expect(item.objectLabel).to eq ['foo']
+    end
+  end
+
+  describe '#objectType=' do
+    let(:item) { described_class.new }
+
+    it 'is settable and gettable' do
+      item.objectType = 'foo'
+      expect(item.objectType).to eq ['foo']
+    end
+  end
+
+  describe '#other_ids=' do
+    let(:item) { described_class.new }
+
+    it 'is settable and gettable' do
+      item.other_ids = ['catkey:123', 'other:566']
+      expect(item.otherId).to eq ['catkey:123', 'other:566']
+    end
+  end
+
+  describe '#tag=' do
+    let(:item) { described_class.new }
+
+    it 'is settable and gettable' do
+      item.tag = ['tag:1', 'tag:2']
+      expect(item.tags).to eq ['tag:1', 'tag:2']
+    end
+  end
+
   describe '#remove_druid_prefix' do
     before do
       allow(Deprecation).to receive(:warn)


### PR DESCRIPTION
The registration service shouldn't know about datastreams