### PR TITLE
Deprecate Dor::ReleaseTagService and Dor::ReleaseTags::Purl

### DIFF
--- a/lib/dor/indexers/releasable_indexer.rb
+++ b/lib/dor/indexers/releasable_indexer.rb
@@ -12,7 +12,6 @@ module Dor
     # @return [Hash] the partial solr document for releasable concerns
     def to_solr
       solr_doc = {}
-
       # TODO: sort of worried about the performance impact in bulk reindex
       # situations, since released_for recurses all parent collections.  jmartin 2015-07-14
       released_for.each do |release_target, release_info|

--- a/lib/dor/release_tags/purl.rb
+++ b/lib/dor/release_tags/purl.rb
@@ -6,6 +6,7 @@ module Dor
       # Determine projects in which an item is released
       # @param [String] pid identifier of the item to get the release tags for
       def initialize(pid:, purl_host:)
+        Deprecation.warn(self, "Dor::ReleaseTags::Purl is deprecated and will be removed in dor-services 9.0. (it's moving to dor-services-app)")
         @pid = pid
         @purl_host = purl_host
       end

--- a/lib/dor/services/collection_service.rb
+++ b/lib/dor/services/collection_service.rb
@@ -2,7 +2,7 @@
 
 module Dor
   # Adds and removes collections to and from objects
-  # Collections are added as Compollections and Sets.
+  # Collections are added as Collections and Sets.
   class CollectionService
     def initialize(obj)
       @obj = obj

--- a/lib/dor/services/release_tag_service.rb
+++ b/lib/dor/services/release_tag_service.rb
@@ -10,6 +10,7 @@ module Dor
     end
 
     def initialize(item)
+      Deprecation.warn(self, "Dor::ReleaseTagService is deprecated and will be removed in dor-services 9.0. (it's moving to dor-services-app)")
       @identity_metadata_service = ReleaseTags::IdentityMetadata.new(item)
       @purl_service = ReleaseTags::Purl.new(pid: item.pid, purl_host: Dor::Config.stacks.document_cache_host)
     end

--- a/spec/datastreams/rights_metadata_spec.rb
+++ b/spec/datastreams/rights_metadata_spec.rb
@@ -336,8 +336,10 @@ RSpec.describe Dor::RightsMetadataDS do
   describe 'to_solr' do
     let(:wf_indexer) { instance_double(Dor::WorkflowsIndexer, to_solr: {}) }
     let(:process_indexer) { instance_double(Dor::ProcessableIndexer, to_solr: {}) }
+    let(:release_indexer) { instance_double(Dor::ReleasableIndexer, to_solr: {}) }
 
     before do
+      allow(Dor::ReleasableIndexer).to receive(:new).and_return(release_indexer)
       allow(Dor::WorkflowsIndexer).to receive(:new).and_return(wf_indexer)
       allow(Dor::ProcessableIndexer).to receive(:new).and_return(process_indexer)
       allow(OpenURI).to receive(:open_uri).with('https://purl-test.stanford.edu/bb046xn0881.xml').and_return('<xml/>')

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -19,8 +19,10 @@ RSpec.describe Dor::Collection do
     let(:collection) { described_class.new(pid: 'foo:123') }
     let(:wf_indexer) { instance_double(Dor::WorkflowsIndexer, to_solr: {}) }
     let(:process_indexer) { instance_double(Dor::ProcessableIndexer, to_solr: {}) }
+    let(:release_indexer) { instance_double(Dor::ReleasableIndexer, to_solr: {}) }
 
     before do
+      allow(Dor::ReleasableIndexer).to receive(:new).and_return(release_indexer)
       allow(Dor::WorkflowsIndexer).to receive(:new).and_return(wf_indexer)
       allow(Dor::ProcessableIndexer).to receive(:new).and_return(process_indexer)
     end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -109,8 +109,10 @@ RSpec.describe Dor::Item do
 
     let(:wf_indexer) { instance_double(Dor::WorkflowsIndexer, to_solr: {}) }
     let(:process_indexer) { instance_double(Dor::ProcessableIndexer, to_solr: {}) }
+    let(:release_indexer) { instance_double(Dor::ReleasableIndexer, to_solr: {}) }
 
     before do
+      allow(Dor::ReleasableIndexer).to receive(:new).and_return(release_indexer)
       allow(Dor::WorkflowsIndexer).to receive(:new).and_return(wf_indexer)
       allow(Dor::ProcessableIndexer).to receive(:new).and_return(process_indexer)
     end

--- a/spec/release_tags/purl_spec.rb
+++ b/spec/release_tags/purl_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe Dor::ReleaseTags::Purl do
   let(:releases) { described_class.new(pid: druid, purl_host: 'purl-test.stanford.edu') }
 
   describe '#released_for' do
+    before do
+      allow(Deprecation).to receive(:warn)
+    end
+
     let(:xml) { Nokogiri::XML(response) }
 
     context 'for targets that are listed on the purl but not in new tag generation' do

--- a/spec/services/release_tag_service_spec.rb
+++ b/spec/services/release_tag_service_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Dor::ReleaseTagService do
   before do
+    allow(Deprecation).to receive(:warn)
     allow(Dor::Config.stacks).to receive(:document_cache_host).and_return('purl-test.stanford.edu')
   end
 


### PR DESCRIPTION
These classes will be moving to dor-services-app which will break the service dependency on PURL.