### PR TITLE
Remove unnecessary dependency on druid-tools

### DIFF
--- a/dor-services.gemspec
+++ b/dor-services.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |s|
 
   # Stanford dependencies
   s.add_dependency 'dor-rights-auth', '~> 1.0', '>= 1.2.0'
-  s.add_dependency 'druid-tools', '>= 0.4.1'
   s.add_dependency 'stanford-mods', '>= 2.3.1'
   s.add_dependency 'stanford-mods-normalizer', '~> 0.1'
 

--- a/lib/dor-services.rb
+++ b/lib/dor-services.rb
@@ -47,8 +47,6 @@ module Dor
 
   require 'dor/datastreams/datastream_spec_solrizer'
 
-  require 'druid-tools'
-
   # datastreams
   autoload_under 'datastreams' do
     autoload :AdministrativeMetadataDS


### PR DESCRIPTION
## Why was this change made?

It's not needed.

## Was the usage documentation (e.g. wiki, README) updated?
n/a