### PR TITLE
Add etd model properties

### DIFF
--- a/lib/dor/models/etd.rb
+++ b/lib/dor/models/etd.rb
@@ -12,6 +12,22 @@ module Dor
     has_many :supplemental_files, property: :is_constituent_of, class_name: 'Part'
     has_many :permission_files, property: :is_dependent_of, class_name: 'Part'
 
+    has_attributes :name, :prefix, :suffix, :major, :degree, :advisor, :etd_type,
+                   :title, :abstract, :containscopyright, :copyrightclearance,
+                   :sulicense, :cclicense, :cclicensetype, :embargo,
+                   :external_visibility, :term, :sub, :univid, :sunetid, :ps_career,
+                   :ps_program, :ps_plan, :ps_subplan, :dissertation_id, :provost,
+                   :degreeconfyr, :schoolname, :department, :readerapproval,
+                   :readercomment, :readeractiondttm, :regapproval, :regcomment,
+                   :regactiondttm, :documentaccess, :submit_date, :symphonyStatus,
+                   datastream: 'properties', multiple: false
+
+    has_attributes :citation_verified, :abstract_provided, :dissertation_uploaded,
+                   :supplemental_files_uploaded, :permissions_provided,
+                   :permission_files_uploaded, :rights_selected,
+                   :cc_license_selected, :submitted_to_registrar,
+                   datastream: 'workflow', multiple: false
+
     has_metadata name: 'properties', type: ActiveFedora::SimpleDatastream, versionable: false do |m|
       m.field 'name',  :string                    # PS:name
       m.field 'prefix', :string                   # PS:prefix

--- a/lib/dor/models/part.rb
+++ b/lib/dor/models/part.rb
@@ -7,6 +7,8 @@ module Dor
     belongs_to :supplemental_file_for, property: :is_constituent_of, class_name: 'Etd' # relationship between supplemental file and parent etd
     belongs_to :permission_file_for, property: :is_dependent_of, class_name: 'Etd' # relationsihip between permission file and parent etd
 
+    has_attributes :file_name, :size, datastream: 'properties', multiple: false
+
     has_metadata name: 'properties', type: ActiveFedora::SimpleDatastream, versionable: false do |m|
       m.field 'file_name', :string
       m.field 'size', :string

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -37,4 +37,24 @@ RSpec.describe Dor::Etd do
     eds = etd.datastreams['embargoMetadata']
     expect(eds).to be_a_kind_of Dor::EmbargoMetadataDS
   end
+
+  describe '#name' do
+    subject { etd.name }
+
+    before do
+      etd.name = 'Bob'
+    end
+
+    it { is_expected.to eq 'Bob' }
+  end
+
+  describe '#citation_verified' do
+    subject { etd.citation_verified }
+
+    before do
+      etd.citation_verified = 'true'
+    end
+
+    it { is_expected.to eq 'true' }
+  end
 end

--- a/spec/models/part_spec.rb
+++ b/spec/models/part_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Dor::Part do
+  let(:part) do
+    described_class.new
+  end
+
+  describe '#file_name' do
+    subject { part.file_name }
+
+    before do
+      part.file_name = 'thesis.pdf'
+    end
+
+    it { is_expected.to eq 'thesis.pdf' }
+  end
+
+  describe '#size' do
+    subject { part.size }
+
+    before do
+      part.size = '90000'
+    end
+
+    it { is_expected.to eq '90000' }
+  end
+end


### PR DESCRIPTION


## Why was this change made?

These have previously been added to hydra_etd, but they also would be used in dor-services-app and common-accessioning.

Use of these properties will help us migrate away from Fedora 3

## Was the usage documentation (e.g. wiki, README) updated?
n/a