### PR TITLE
Deprecate embargoable methods

### DIFF
--- a/lib/dor/models/concerns/embargoable.rb
+++ b/lib/dor/models/concerns/embargoable.rb
@@ -17,12 +17,12 @@ module Dor
     def release_embargo(release_agent = 'unknown')
       embargo_service.release(release_agent)
     end
-    deprecation_deprecate release_embargo: 'Use the method in EmbargoService instead'
+    deprecation_deprecate release_embargo: 'this moved to dor-service-app'
 
     def release_20_pct_vis_embargo(release_agent = 'unknown')
       embargo_service.release_20_pct_vis(release_agent)
     end
-    deprecation_deprecate release_20_pct_vis_embargo: 'Use the method in EmbargoService instead'
+    deprecation_deprecate release_20_pct_vis_embargo: 'this moved to dor-service-app'
 
     def embargoed?
       embargoMetadata.status == 'embargoed'

--- a/lib/dor/models/concerns/embargoable.rb
+++ b/lib/dor/models/concerns/embargoable.rb
@@ -17,10 +17,12 @@ module Dor
     def release_embargo(release_agent = 'unknown')
       embargo_service.release(release_agent)
     end
+    deprecation_deprecate release_embargo: 'Use the method in EmbargoService instead'
 
     def release_20_pct_vis_embargo(release_agent = 'unknown')
       embargo_service.release_20_pct_vis(release_agent)
     end
+    deprecation_deprecate release_20_pct_vis_embargo: 'Use the method in EmbargoService instead'
 
     def embargoed?
       embargoMetadata.status == 'embargoed'
@@ -29,6 +31,7 @@ module Dor
     def update_embargo(new_date)
       embargo_service.update(new_date)
     end
+    deprecation_deprecate update_embargo: 'Use the method in EmbargoService instead'
 
     def embargo_service
       EmbargoService.new(self)

--- a/lib/dor/services/embargo_service.rb
+++ b/lib/dor/services/embargo_service.rb
@@ -35,6 +35,7 @@ module Dor
 
       events.add_event('embargo', release_agent, 'Embargo released')
     end
+    deprecation_deprecate release: 'this moved to dor-service-app'
 
     def release_20_pct_vis(release_agent)
       # Set status to released
@@ -55,6 +56,7 @@ module Dor
 
       events.add_event('embargo', release_agent, '20% Visibility Embargo released')
     end
+    deprecation_deprecate release_20_pct_vis: 'this moved to dor-service-app'
 
     def update(new_date)
       raise ArgumentError, 'You cannot change the embargo date of an item that is not embargoed.' if embargoMetadata.status != 'embargoed'

--- a/spec/models/concerns/embargoable_spec.rb
+++ b/spec/models/concerns/embargoable_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Dor::Embargoable do
   end
 
   describe '#release_embargo' do
+    before do
+      allow(Deprecation).to receive(:warn)
+    end
+
     it 'delegates to the EmbargoService' do
       embargo_item.release_embargo('application:embargo-release')
       expect(service).to have_received(:release).with('application:embargo-release')
@@ -23,6 +27,10 @@ RSpec.describe Dor::Embargoable do
   end
 
   describe '#release_20_pct_vis_embargo' do
+    before do
+      allow(Deprecation).to receive(:warn)
+    end
+
     it 'delegates to the EmbargoService' do
       embargo_item.release_20_pct_vis_embargo('application:embargo-release')
       expect(service).to have_received(:release_20_pct_vis).with('application:embargo-release')
@@ -30,6 +38,10 @@ RSpec.describe Dor::Embargoable do
   end
 
   describe '#update_embargo' do
+    before do
+      allow(Deprecation).to receive(:warn)
+    end
+
     let(:time) { Time.now.utc + 1.month }
 
     it 'delegates to the EmbargoService' do

--- a/spec/services/embargo_service_spec.rb
+++ b/spec/services/embargo_service_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe Dor::EmbargoService do
     end
 
     before do
+      allow(Deprecation).to receive(:warn)
       service.release('application:embargo-release')
     end
 
@@ -124,6 +125,7 @@ RSpec.describe Dor::EmbargoService do
     end
 
     before do
+      allow(Deprecation).to receive(:warn)
       service.release_20_pct_vis('application:embargo-release')
     end
 
@@ -185,9 +187,14 @@ RSpec.describe Dor::EmbargoService do
       service.update(Time.now.utc + 1.month)
     end
 
-    it "raises ArgumentError if the item isn't embargoed" do
-      service.release('application:embargo-release')
-      expect { service.update(Time.now.utc + 1.month) }.to raise_error(ArgumentError)
+    context "when the item isn't embargoed" do
+      let(:embargo_item) do
+        Dor::Item.new
+      end
+
+      it 'raises ArgumentError' do
+        expect { service.update(Time.now.utc + 1.month) }.to raise_error(ArgumentError)
+      end
     end
 
     it 'raises ArgumentError if the new date is in the past' do


### PR DESCRIPTION


## Why was this change made?

The are just indirection and we can call the EmbargoService directly

## Was the usage documentation (e.g. wiki, README) updated?
n/a