### PR TITLE
Add use and reproduction to the embargo

### DIFF
--- a/lib/dor/datastreams/embargo_metadata_ds.rb
+++ b/lib/dor/datastreams/embargo_metadata_ds.rb
@@ -9,9 +9,14 @@ module Dor
       t.status
       t.embargo_status(path: 'status', index_as: [:symbol])
       t.release_date(path: 'releaseDate', index_as: [:dateable])
-      t.release_access(path: 'releaseAccess')
+      t.release_access(path: 'releaseAccess') do
+        t.use do
+          t.human(attributes: { type: 'useAndReproduction' })
+        end
+      end
       t.twenty_pct_status(path: 'twentyPctVisibilityStatus', index_as: [:symbol])
       t.twenty_pct_release_date(path: 'twentyPctVisibilityReleaseDate')
+      t.use_and_reproduction_statement(proxy: %i[release_access use human])
     end
 
     # Default EmbargoMetadataDS xml

--- a/spec/datastreams/embargo_metadata_spec.rb
+++ b/spec/datastreams/embargo_metadata_spec.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'nokogiri'
 
-describe Dor::EmbargoMetadataDS do
+RSpec.describe Dor::EmbargoMetadataDS do
   before do
     @ds = described_class.new nil, 'embargoMetadata'
   end
@@ -136,5 +135,17 @@ describe Dor::EmbargoMetadataDS do
       expect(embargo.at_xpath("//releaseAccess/access[@type='read']/machine/world")).to be
       expect(@ds).to be_changed
     end
+  end
+
+  describe 'use_and_reproduction_statement' do
+    subject { ds.use_and_reproduction_statement }
+
+    let(:ds) { described_class.new nil, 'embargoMetadata' }
+
+    before do
+      ds.use_and_reproduction_statement = 'These materials are in the public domain.'
+    end
+
+    it { is_expected.to eq ['These materials are in the public domain.'] }
   end
 end


### PR DESCRIPTION

## Why was this change made?

This is the statement that is used when the embargo expires.
See https://github.com/sul-dlss/google-books/issues/398


## Was the usage documentation (e.g. wiki, README) updated?
n/a