### PR TITLE
Add embargo_release_date to RightsMetadataDS

### DIFF
--- a/lib/dor/datastreams/rights_metadata_ds.rb
+++ b/lib/dor/datastreams/rights_metadata_ds.rb
@@ -20,6 +20,14 @@ module Dor
         t.human
       end
 
+      t._read(path: 'access', attributes: { type: 'read' }) do
+        t.machine do
+          t.embargo_release_date(path: 'embargoReleaseDate', type: :time)
+        end
+      end
+
+      t.embargo_release_date(proxy: %i[_read machine embargo_release_date])
+
       t.creative_commons path: '/use/machine[@type=\'creativeCommons\']', type: 'creativeCommons' do
         t.uri path: '@uri'
       end

--- a/lib/dor/services/embargo_service.rb
+++ b/lib/dor/services/embargo_service.rb
@@ -62,20 +62,10 @@ module Dor
       raise ArgumentError, 'You cannot change the embargo date of an item that is not embargoed.' if embargoMetadata.status != 'embargoed'
       raise ArgumentError, 'You cannot set the embargo date to a past date.' if new_date.past?
 
-      updated = false
-      rightsMetadata.ng_xml.search('//embargoReleaseDate').each do |node|
-        node.content = new_date.beginning_of_day.utc.xmlschema
-        updated = true
-      end
-      rightsMetadata.ng_xml_will_change!
-      rightsMetadata.save
-      raise 'No release date in rights metadata, cannot proceed!' unless updated
-
-      embargoMetadata.ng_xml.xpath('//releaseDate').each do |node|
-        node.content = new_date.beginning_of_day.utc.xmlschema
-      end
-      embargoMetadata.ng_xml_will_change!
-      embargoMetadata.save
+      time = new_date.beginning_of_day.utc
+      rightsMetadata.embargo_release_date = time
+      embargoMetadata.release_date = time
+      obj.save!
     end
 
     private

--- a/spec/datastreams/embargo_metadata_spec.rb
+++ b/spec/datastreams/embargo_metadata_spec.rb
@@ -82,25 +82,19 @@ RSpec.describe Dor::EmbargoMetadataDS do
   end
 
   describe '#release_date' do
+    subject { ds.release_date }
+
+    let(:ds) { described_class.new }
+    let(:time) { DateTime.parse('2039-10-30T12:22:33Z') }
+
     before do
-      @t = Time.now.utc - 10
-      @ds.release_date = @t
+      ds.release_date = time
     end
 
-    it '= sets releaseDate from a Time object' do
-      # does NOT do beginning_of_day truncation, leave that for indexing
-      rd = Time.parse(@ds.term_values(:release_date).first)
-      expect(rd.strftime('%FT%T%z')).to eq(@t.strftime('%FT%T%z')) # not strictly equal since "now" has millesecond granularity
-    end
+    it { is_expected.to eq [time] }
 
     it '= marks the datastram as changed' do
-      expect(@ds).to be_changed
-    end
-
-    it 'gets the current value of releaseDate as a Time object' do
-      rd = @ds.release_date
-      expect(rd).to be_a(Time)
-      expect(rd).to be < Time.now.utc
+      expect(ds).to be_changed
     end
   end
 

--- a/spec/services/embargo_service_spec.rb
+++ b/spec/services/embargo_service_spec.rb
@@ -167,8 +167,7 @@ RSpec.describe Dor::EmbargoService do
     end
 
     before do
-      allow(embargo_item.rightsMetadata).to receive(:save).and_return(true)
-      allow(embargo_item.embargoMetadata).to receive(:save).and_return(true)
+      allow(embargo_item).to receive(:save!).and_return(true)
     end
 
     it 'indicates the item is embargoed' do
@@ -176,15 +175,9 @@ RSpec.describe Dor::EmbargoService do
     end
 
     it 'updates embargo date' do
-      old_embargo_date = embargo_item.embargoMetadata.release_date
-      service.update(Time.now.utc + 1.month)
-      expect(embargo_item.embargoMetadata.release_date).not_to eq old_embargo_date
-    end
-
-    it 'updates embargo and rights datastreams with content= ' do
-      expect(embargo_item.embargoMetadata).to receive(:ng_xml_will_change!)
-      expect(embargo_item.rightsMetadata).to receive(:ng_xml_will_change!)
-      service.update(Time.now.utc + 1.month)
+      old_embargo_date = embargo_item.embargoMetadata.release_date.first
+      service.update(DateTime.now.utc + 1.month)
+      expect(embargo_item.embargoMetadata.release_date.first).not_to eq old_embargo_date
     end
 
     context "when the item isn't embargoed" do


### PR DESCRIPTION

## Why was this change made?
Made EmbargoMetadataDS#release_date switch to OM methods so it works in the same way as RightsMetadataDS#embargo_release_date.
As this avoids some XML parsing, it should help us migrate away from Fedora 3.

Ref https://github.com/sul-dlss/google-books/issues/399


## Was the usage documentation (e.g. wiki, README) updated?

n/a