### PR TITLE
Embargo indexing fix

### DIFF
--- a/lib/dor/datastreams/embargo_metadata_ds.rb
+++ b/lib/dor/datastreams/embargo_metadata_ds.rb
@@ -36,7 +36,7 @@ module Dor
     def to_solr(solr_doc = {}, *args)
       solr_doc = super
       rd20 = twenty_pct_release_date
-      ::Solrizer.insert_field(solr_doc, 'embargo_release', release_date.first.utc.strftime('%FT%TZ'), :dateable) unless release_date.blank?
+      ::Solrizer.insert_field(solr_doc, 'embargo_release', release_date.first.utc.strftime('%FT%TZ'), :dateable) unless release_date.first.blank?
       ::Solrizer.insert_field(solr_doc, 'twenty_pct_visibility_release', rd20.utc.strftime('%FT%TZ'), :dateable) unless rd20.blank?
       solr_doc
     end

--- a/spec/datastreams/embargo_metadata_spec.rb
+++ b/spec/datastreams/embargo_metadata_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Dor::EmbargoMetadataDS do
 
   context 'Marshalling to and from a Fedora Datastream' do
     let(:dsxml) do
-      <<-EOF
+      <<-XML
           <embargoMetadata>
             <status>embargoed</status>
             <releaseDate>2011-10-12T15:47:52-07:00</releaseDate>
@@ -28,7 +28,7 @@ RSpec.describe Dor::EmbargoMetadataDS do
               </access>
             </releaseAccess>
           </embargoMetadata>
-      EOF
+      XML
     end
 
     it 'creates itself from xml' do
@@ -41,7 +41,7 @@ RSpec.describe Dor::EmbargoMetadataDS do
     end
 
     it 'creates a simple default with #new' do
-      emb_xml = <<-EOF
+      emb_xml = <<-XML
       <embargoMetadata>
         <status/>
         <releaseDate/>
@@ -49,7 +49,7 @@ RSpec.describe Dor::EmbargoMetadataDS do
         <twentyPctVisibilityStatus/>
         <twentyPctVisibilityReleaseDate/>
       </embargoMetadata>
-      EOF
+      XML
       expect(@ds.to_xml).to be_equivalent_to(emb_xml)
     end
 
@@ -95,6 +95,39 @@ RSpec.describe Dor::EmbargoMetadataDS do
 
     it '= marks the datastram as changed' do
       expect(ds).to be_changed
+    end
+  end
+
+  describe '#to_solr' do
+    it 'copes with empty releaseDate' do
+      empty_rel_date_xml =
+        <<-XML
+          <embargoMetadata>
+            <status/>
+            <releaseDate/>
+            <releaseAccess/>
+            <twentyPctVisibilityStatus/>
+            <twentyPctVisibilityReleaseDate/>
+          </embargoMetadata>
+        XML
+      ds = described_class.from_xml(empty_rel_date_xml)
+      release_date_field = Solrizer.solr_name('embargo_release', :dateable)
+      expect(ds.to_solr).not_to match a_hash_including(release_date_field)
+    end
+
+    it 'copes with missing releaseDate' do
+      missing_rel_date_xml =
+        <<-XML
+          <embargoMetadata>
+            <status/>
+            <releaseAccess/>
+            <twentyPctVisibilityStatus/>
+            <twentyPctVisibilityReleaseDate/>
+          </embargoMetadata>
+        XML
+      ds = described_class.from_xml(missing_rel_date_xml)
+      release_date_field = Solrizer.solr_name('embargo_release', :dateable)
+      expect(ds.to_solr).not_to match a_hash_including(release_date_field)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -118,7 +118,7 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10
+  # config.profile_examples = 10
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing


### PR DESCRIPTION
## Why was this change made?

To fix error in dor_indexing_app tests when updating to dor-services 9.2.0 https://github.com/sul-dlss/dor_indexing_app/pull/373

Note that 
- there was no test for the code change that broke it
- it may be unrealistic for there to be an embargo without a release date in our actual data

## Was the usage documentation (e.g. wiki, README) updated?

na