### PR TITLE
Add format_reviewed field to etd workflow datastream

### DIFF
--- a/lib/dor/models/etd.rb
+++ b/lib/dor/models/etd.rb
@@ -22,10 +22,11 @@ module Dor
                    :regactiondttm, :documentaccess, :submit_date, :symphonyStatus,
                    datastream: 'properties', multiple: false
 
-    has_attributes :citation_verified, :abstract_provided, :dissertation_uploaded,
-                   :supplemental_files_uploaded, :permissions_provided,
-                   :permission_files_uploaded, :rights_selected,
-                   :cc_license_selected, :submitted_to_registrar,
+    has_attributes :citation_verified, :abstract_provided, :format_reviewed,
+                   :dissertation_uploaded, :supplemental_files_uploaded,
+                   :permissions_provided, :permission_files_uploaded,
+                   :rights_selected, :cc_license_selected,
+                   :submitted_to_registrar,
                    datastream: 'workflow', multiple: false
 
     has_metadata name: 'properties', type: ActiveFedora::SimpleDatastream, versionable: false do |m|
@@ -77,6 +78,7 @@ module Dor
     has_metadata name: 'workflow', type: ActiveFedora::SimpleDatastream, versionable: false do |m|
       m.field 'citation_verified', :string
       m.field 'abstract_provided', :string
+      m.field 'format_reviewed', :string
       m.field 'dissertation_uploaded', :string
       m.field 'supplemental_files_uploaded', :string
       m.field 'permissions_provided', :string

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -57,4 +57,14 @@ RSpec.describe Dor::Etd do
 
     it { is_expected.to eq 'true' }
   end
+
+  describe '#format_reviewed' do
+    subject { etd.format_reviewed }
+
+    before do
+      etd.format_reviewed = 'false'
+    end
+
+    it { is_expected.to eq 'false' }
+  end
 end


### PR DESCRIPTION
Connects to sul-dlss/hydra_etd#320

## Why was this change made?

To support a new ETD workflow step

## Was the usage documentation (e.g. wiki, README) updated?
No