### PR TITLE
Set the agreement class correctly

### DIFF
--- a/lib/dor/models/admin_policy_object.rb
+++ b/lib/dor/models/admin_policy_object.rb
@@ -7,7 +7,7 @@ module Dor
     has_metadata name: 'administrativeMetadata', type: Dor::AdministrativeMetadataDS, label: 'Administrative Metadata'
     has_metadata name: 'roleMetadata',           type: Dor::RoleMetadataDS,           label: 'Role Metadata'
     has_metadata name: 'defaultObjectRights',    type: Dor::DefaultObjectRightsDS,    label: 'Default Object Rights'
-    belongs_to :agreement_object, property: :referencesAgreement, class_name: 'Dor::Item'
+    belongs_to :agreement_object, property: :referencesAgreement, class_name: 'Dor::Agreement'
 
     delegate :add_roleplayer, :purge_roles, :roles, to: :roleMetadata
     delegate :mods_title, :mods_title=, to: :descMetadata


### PR DESCRIPTION

## Why was this change made?

If it's not agreement, then previously set agreements are not removed.

See https://github.com/samvera/active_fedora/blob/8.x-stable/lib/active_fedora/associations/belongs_to_association.rb#L91

