### PR TITLE
Allow contentType to be set on an empty datastream

### DIFF
--- a/lib/dor/datastreams/content_metadata_ds.rb
+++ b/lib/dor/datastreams/content_metadata_ds.rb
@@ -6,7 +6,7 @@ module Dor
   class ContentMetadataDS < ActiveFedora::OmDatastream
     set_terminology do |t|
       t.root        path: 'contentMetadata',          index_as: [:not_searchable]
-      t.contentType path: '/contentMetadata/@type',   index_as: [:not_searchable]
+      t.contentType path: { attribute: 'type' },      index_as: [:not_searchable]
       t.stacks      path: '/contentMetadata/@stacks', index_as: [:not_searchable]
       t.resource(index_as: [:not_searchable]) do
         t.id_       path: { attribute: 'id' }
@@ -33,6 +33,10 @@ module Dor
         end
       end
       t.shelved_file_id proxy: %i[resource shelved_file id], index_as: %i[displayable stored_searchable]
+    end
+
+    def self.xml_template
+      Nokogiri::XML.parse('<contentMetadata/>')
     end
 
     ### READ ONLY METHODS

--- a/spec/datastreams/content_metadata_ds_spec.rb
+++ b/spec/datastreams/content_metadata_ds_spec.rb
@@ -246,4 +246,16 @@ RSpec.describe Dor::ContentMetadataDS do
       expect(relationship.first['objectId']).to eq('bb273jy3359')
     end
   end
+
+  describe '#contentType=' do
+    let(:contentMetadata) { described_class.new }
+
+    before do
+      contentMetadata.contentType = 'map'
+    end
+
+    it 'sets the value' do
+      expect(contentMetadata.to_xml).to be_equivalent_to '<contentMetadata type="map"/>'
+    end
+  end
 end


### PR DESCRIPTION


## Why was this change made?
This is mostly useful for testing without loading an XML fixture


## How was this change tested?
Test suite


## Which documentation and/or configurations were updated?

n/a

