### PR TITLE
new rubocop fixes

### DIFF
--- a/lib/dor/datastreams/content_metadata_ds.rb
+++ b/lib/dor/datastreams/content_metadata_ds.rb
@@ -61,11 +61,11 @@ module Dor
     # @param [String] fileId the linked druid's resource's file identifier
     # @param [String] mimetype the file's MIME type
     # @return [Nokogiri::XML::Element]
-    def generate_external_file_node(objectId, resourceId, fileId, mimetype)
+    def generate_external_file_node(object_id, resource_id, file_id, mimetype)
       externalFile = ng_xml.create_element 'externalFile'
-      externalFile[:objectId]   = objectId
-      externalFile[:resourceId] = resourceId
-      externalFile[:fileId]     = fileId
+      externalFile[:objectId]   = object_id
+      externalFile[:resourceId] = resource_id
+      externalFile[:fileId]     = file_id
       externalFile[:mimetype]   = mimetype
       externalFile
     end
@@ -74,10 +74,10 @@ module Dor
     #   <relationship type="alsoAvailableAs" objectId="druid:mn123pq4567" />
     # @param [String] objectId the linked druid
     # @return [Nokogiri::XML::Element]
-    def generate_also_available_as_node(objectId)
+    def generate_also_available_as_node(object_id)
       relationship = ng_xml.create_element 'relationship'
       relationship[:type] = 'alsoAvailableAs'
-      relationship[:objectId] = objectId
+      relationship[:objectId] = object_id
       relationship
     end
 

--- a/lib/dor/datastreams/embargo_metadata_ds.rb
+++ b/lib/dor/datastreams/embargo_metadata_ds.rb
@@ -68,8 +68,8 @@ module Dor
 
     # Sets the 20% visibility release date.  Converts the date to beginning-of-day, UTC to help with Solr indexing
     # @param [Time] rd A Time object represeting the release date.  By default, it is set to now
-    def twenty_pct_release_date=(rd = Time.now.utc)
-      update_values([:twenty_pct_release_date] => rd.beginning_of_day.utc.xmlschema)
+    def twenty_pct_release_date=(release_date = Time.now.utc)
+      update_values([:twenty_pct_release_date] => release_date.beginning_of_day.utc.xmlschema)
     end
 
     # Current twentyPctVisibilityReleaseDate value

--- a/lib/dor/datastreams/version_metadata_ds.rb
+++ b/lib/dor/datastreams/version_metadata_ds.rb
@@ -168,8 +168,8 @@ module Dor
       current_version_node[:tag].to_s
     end
 
-    def tag_for_version(versionId)
-      nodes = ng_xml.search('//version[@versionId=\'' + versionId + '\']')
+    def tag_for_version(version_id)
+      nodes = ng_xml.search('//version[@versionId=\'' + version_id + '\']')
       if nodes.length == 1
         nodes.first['tag'].to_s
       else
@@ -178,8 +178,8 @@ module Dor
     end
 
     # @return [String] The description for the specified version, or empty string if there is no description
-    def description_for_version(versionId)
-      nodes = ng_xml.search('//version[@versionId=\'' + versionId + '\']')
+    def description_for_version(version_id)
+      nodes = ng_xml.search('//version[@versionId=\'' + version_id + '\']')
       if nodes.length == 1 && nodes.first.at_xpath('description')
         nodes.first.at_xpath('description').content.to_s
       else

--- a/spec/datastreams/content_metadata_ds_spec.rb
+++ b/spec/datastreams/content_metadata_ds_spec.rb
@@ -248,14 +248,14 @@ RSpec.describe Dor::ContentMetadataDS do
   end
 
   describe '#contentType=' do
-    let(:contentMetadata) { described_class.new }
+    let(:content_metadata) { described_class.new }
 
     before do
-      contentMetadata.contentType = 'map'
+      content_metadata.contentType = 'map'
     end
 
     it 'sets the value' do
-      expect(contentMetadata.to_xml).to be_equivalent_to '<contentMetadata type="map"/>'
+      expect(content_metadata.to_xml).to be_equivalent_to '<contentMetadata type="map"/>'
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

~~Rubocop failing locally for me now on master branch~~

Never mind, rubocop is working fine on master when i updated my local version of the rubocop gem.  So this is not needed to make rubocop happy,


## How was this change tested?

Run the test suite locally, no rubocop or test failures



## Which documentation and/or configurations were updated?

None


