### PR TITLE
cdl should indicate it has rights of none; for consistency with how we do cocina mapping

### DIFF
--- a/lib/dor/datastreams/rights_metadata_ds.rb
+++ b/lib/dor/datastreams/rights_metadata_ds.rb
@@ -168,8 +168,6 @@ module Dor
         'Stanford'
       elsif xml.search('//rightsMetadata/access[@type=\'read\']/machine/world').length == 1
         'World'
-      elsif xml.search('//rightsMetadata/access[@type=\'read\']/machine/cdl').length == 1
-        'Controlled Digital Lending'
       elsif xml.search('//rightsMetadata/access[@type=\'discover\']/machine/none').length == 1
         'Dark'
       else

--- a/spec/datastreams/rights_metadata_spec.rb
+++ b/spec/datastreams/rights_metadata_spec.rb
@@ -332,9 +332,9 @@ RSpec.describe Dor::RightsMetadataDS do
       expect(rights_md.rights).to eq 'World'
     end
 
-    it 'indicates the rights as controlled digital lending' do
+    it 'indicates the rights as None for controlled digital lending (which will have a separate attribute to indicate it is cdl)' do
       rights_md.set_read_rights 'cdl-stanford-nd'
-      expect(rights_md.rights).to eq 'Controlled Digital Lending'
+      expect(rights_md.rights).to eq 'None'
     end
 
     it 'indicates the rights as stanford' do


### PR DESCRIPTION
## Why was this change made?

Part of sul-dlss/argo#2200  -- controlled digital lending objects will indicate they have rights set like citation only objects, but will include a new "controlled_digital_lending" boolean attribute to disambiguate them

## How was this change tested?

Unit test


## Which documentation and/or configurations were updated?



